### PR TITLE
zfs: add 'received' property source, handle 'any' source correctly an…

### DIFF
--- a/zfs/diff.go
+++ b/zfs/diff.go
@@ -248,7 +248,7 @@ func IsPlaceholder(p *DatasetPath, placeholderPropertyValue string) (isPlacehold
 
 // for nonexistent FS, isPlaceholder == false && err == nil
 func ZFSIsPlaceholderFilesystem(p *DatasetPath) (isPlaceholder bool, err error) {
-	props, err := zfsGet(p.ToString(), []string{ZREPL_PLACEHOLDER_PROPERTY_NAME}, sourceLocal)
+	props, err := zfsGet(p.ToString(), []string{ZREPL_PLACEHOLDER_PROPERTY_NAME}, sourceAny)
 	if err == io.ErrUnexpectedEOF {
 		// interpret this as an early exit of the zfs binary due to the fs not existing
 		return false, nil

--- a/zfs/zfs.go
+++ b/zfs/zfs.go
@@ -601,17 +601,20 @@ const (
 	sourceInherited
 	sourceNone
 	sourceTemporary
+	sourceReceived
 
 	sourceAny zfsPropertySource = ^zfsPropertySource(0)
 )
 
 func (s zfsPropertySource) zfsGetSourceFieldPrefixes() []string {
-	prefixes := make([]string, 0, 5)
+	prefixes := make([]string, 0, 7)
 	if s&sourceLocal != 0 {prefixes = append(prefixes, "local")}
 	if s&sourceDefault != 0 {prefixes = append(prefixes, "default")}
 	if s&sourceInherited != 0 {prefixes = append(prefixes, "inherited")}
 	if s&sourceNone != 0 {prefixes = append(prefixes, "-")}
 	if s&sourceTemporary != 0 { prefixes = append(prefixes, "temporary")}
+	if s&sourceReceived != 0 { prefixes = append(prefixes, "received")}
+	if s == sourceAny { prefixes = append(prefixes, "") }
 	return prefixes
 }
 

--- a/zfs/zfs_test.go
+++ b/zfs/zfs_test.go
@@ -39,7 +39,8 @@ func TestZFSPropertySource(t *testing.T) {
 	}{
 		{
 			in: sourceAny,
-			exp: []string{"local", "default", "inherited", "-", "temporary"},
+			// although empty prefix matches any source
+			exp: []string{"local", "default", "inherited", "-", "temporary", "received", ""},
 		},
 		{
 			in: sourceTemporary,


### PR DESCRIPTION
…d use 'any' for placeholder FS detection

we want was first noticed in zfs 0.8rc1

Upstream doc PR: https://github.com/zfsonlinux/zfs/pull/8134