### PR TITLE
batch snapshot destroys using comma syntax if supported

### DIFF
--- a/daemon/logging/build_logging.go
+++ b/daemon/logging/build_logging.go
@@ -37,7 +37,7 @@ func OutletsFromConfig(in config.LoggingOutletEnumList) (*logger.Outlets, error)
 	var syslogOutlets, stdoutOutlets int
 	for lei, le := range in {
 
-		outlet, minLevel, err := parseOutlet(le)
+		outlet, minLevel, err := ParseOutlet(le)
 		if err != nil {
 			return nil, errors.Wrapf(err, "cannot parse outlet #%d", lei)
 		}
@@ -123,7 +123,7 @@ func parseLogFormat(i interface{}) (f EntryFormatter, err error) {
 
 }
 
-func parseOutlet(in config.LoggingOutletEnum) (o logger.Outlet, level logger.Level, err error) {
+func ParseOutlet(in config.LoggingOutletEnum) (o logger.Outlet, level logger.Level, err error) {
 
 	parseCommon := func(common config.LoggingOutletCommon) (logger.Level, EntryFormatter, error) {
 		if common.Level == "" || common.Format == "" {

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -31,6 +31,7 @@ We use the following annotations for classifying changes:
 * Linux ARM64 Docker build support & binary builds
 * Go modules for dependency management both inside and outside of GOPATH
   (``lazy.sh`` and ``Makefile`` force ``GO111MODULE=on``)
+* |feature| Use ``zfs destroy pool/fs@snap1,snap2,...`` CLI feature if available
 
 0.1.1
 -----

--- a/platformtest/harness/harness.go
+++ b/platformtest/harness/harness.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"time"
+
+	"github.com/fatih/color"
+	"github.com/zrepl/zrepl/config"
+	"github.com/zrepl/zrepl/daemon/logging"
+	"github.com/zrepl/zrepl/logger"
+	"github.com/zrepl/zrepl/platformtest"
+	"github.com/zrepl/zrepl/platformtest/tests"
+)
+
+func main() {
+
+	root := flag.String("root", "", "empty root filesystem under which we conduct the platform test")
+	flag.Parse()
+	if *root == "" {
+		panic(*root)
+	}
+
+	outlets := logger.NewOutlets()
+	outlet, level, err := logging.ParseOutlet(config.LoggingOutletEnum{Ret: &config.StdoutLoggingOutlet{
+		LoggingOutletCommon: config.LoggingOutletCommon{
+			Level:  "debug",
+			Format: "human",
+		},
+	}})
+	if err != nil {
+		panic(err)
+	}
+	outlets.Add(outlet, level)
+	logger := logger.NewLogger(outlets, 1*time.Second)
+
+	ctx := &platformtest.Context{
+		Context:     platformtest.WithLogger(context.Background(), logger),
+		RootDataset: *root,
+	}
+
+	bold := color.New(color.Bold)
+	for _, c := range tests.Cases {
+		bold.Printf("BEGIN TEST CASE %s\n", c)
+		c(ctx)
+		bold.Printf("DONE  TEST CASE %s\n", c)
+		fmt.Println()
+	}
+
+}

--- a/platformtest/harness/harness_test.go
+++ b/platformtest/harness/harness_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// Idea taken from
+// https://github.com/openSUSE/umoci/blob/v0.2.1/cmd/umoci/main_test.go
+//
+// How to generate coverage:
+// go test -c -covermode=atomic -cover -coverpkg github.com/zrepl/zrepl/...
+// sudo ../logmockzfs/logzfsenv /tmp/zrepl_platform_test.log /usr/bin/zfs \
+//     ./harness.test -test.coverprofile=/tmp/harness.out \
+//     -test.v __DEVEL--i-heard-you-like-tests \
+//     -root rpool/zreplplayground
+//  go tool cover -html=/tmp/harness.out -o /tmp/harness.html
+//
+// Merge with existing coverage reports using gocovmerge:
+//  https://github.com/wadey/gocovmerge
+
+func TestMain(t *testing.T) {
+	var (
+		args []string
+		run  bool
+	)
+
+	for _, arg := range os.Args {
+		switch {
+		case arg == "__DEVEL--i-heard-you-like-tests":
+			run = true
+		case strings.HasPrefix(arg, "-test"):
+		case strings.HasPrefix(arg, "__DEVEL"):
+		default:
+			args = append(args, arg)
+		}
+	}
+	os.Args = args
+
+	if run {
+		main()
+	}
+}

--- a/platformtest/logmockzfs/logzfsenv
+++ b/platformtest/logmockzfs/logzfsenv
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -ue
+export ZREPL_MOCK_ZFS_COMMAND_LOG="$1"
+shift
+export ZREPL_MOCK_ZFS_PATH="$1"
+shift
+export PATH="$(dirname "${BASH_SOURCE[0]}" )":"$PATH"
+args=("$@")
+exec "${args[@]}"

--- a/platformtest/logmockzfs/zfs
+++ b/platformtest/logmockzfs/zfs
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -eu
+args=("$@")
+
+if [ -n "$ZREPL_MOCK_ZFS_COMMAND_LOG" ]; then
+    (
+        flock -x 200
+        jq --compact-output -n --argjson args "$(printf '%s\0' "${args[@]}" | jq -Rsc 'split("\u0000")')" '{date: now|strflocaltime("%Y-%m-%dT%H:%M:%S"), command: $args}' >> "$ZREPL_MOCK_ZFS_COMMAND_LOG"
+    ) 200>"$ZREPL_MOCK_ZFS_COMMAND_LOG".lock
+fi
+
+exec "$ZREPL_MOCK_ZFS_PATH" "${args[@]}"

--- a/platformtest/platformtest.go
+++ b/platformtest/platformtest.go
@@ -1,0 +1,24 @@
+package platformtest
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type Context struct {
+	context.Context
+	RootDataset string
+}
+
+var _ assert.TestingT = (*Context)(nil)
+var _ require.TestingT = (*Context)(nil)
+
+func (c *Context) Errorf(format string, args ...interface{}) {
+	getLog(c).Printf(format, args...)
+}
+
+func (c *Context) FailNow() {
+	panic(nil)
+}

--- a/platformtest/platformtest_exec.go
+++ b/platformtest/platformtest_exec.go
@@ -1,0 +1,42 @@
+package platformtest
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+)
+
+type ex struct {
+	log Logger
+}
+
+func newEx(log Logger) *ex {
+	return &ex{log}
+}
+
+func (e *ex) RunExpectSuccessNoOutput(ctx context.Context, cmd string, args ...string) error {
+	return e.runNoOutput(true, ctx, cmd, args...)
+}
+
+func (e *ex) RunExpectFailureNoOutput(ctx context.Context, cmd string, args ...string) error {
+	return e.runNoOutput(false, ctx, cmd, args...)
+}
+
+func (e *ex) runNoOutput(expectSuccess bool, ctx context.Context, cmd string, args ...string) error {
+	log := e.log.WithField("command", fmt.Sprintf("%q %q", cmd, args))
+	log.Debug("begin executing")
+	defer log.Debug("done executing")
+	ecmd := exec.CommandContext(ctx, cmd, args...)
+	// use circlog and capture stdout
+	err := ecmd.Run()
+	ee, ok := err.(*exec.ExitError)
+	if err != nil && !ok {
+		panic(err)
+	}
+	if expectSuccess && err != nil {
+		return fmt.Errorf("expecting no error, got error: %s\n%s", err, ee.Stderr)
+	} else if !expectSuccess && err == nil {
+		return fmt.Errorf("expecting error, got no error")
+	}
+	return nil
+}

--- a/platformtest/platformtest_logging.go
+++ b/platformtest/platformtest_logging.go
@@ -1,0 +1,24 @@
+package platformtest
+
+import (
+	"context"
+
+	"github.com/zrepl/zrepl/logger"
+)
+
+type Logger = logger.Logger
+
+type contextKey int
+
+const (
+	contextKeyLogger contextKey = iota
+)
+
+func WithLogger(ctx context.Context, logger Logger) context.Context {
+	ctx = context.WithValue(ctx, contextKeyLogger, logger)
+	return ctx
+}
+
+func getLog(ctx context.Context) Logger {
+	return ctx.Value(contextKeyLogger).(Logger)
+}

--- a/platformtest/platformtest_ops.go
+++ b/platformtest/platformtest_ops.go
@@ -1,0 +1,275 @@
+package platformtest
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"unicode"
+)
+
+type Execer interface {
+	RunExpectSuccessNoOutput(ctx context.Context, cmd string, args ...string) error
+	RunExpectFailureNoOutput(ctx context.Context, cmd string, args ...string) error
+}
+
+type Stmt interface {
+	Run(context context.Context, e Execer) error
+}
+
+type Op string
+
+const (
+	AssertExists    Op = "!E"
+	AssertNotExists Op = "!N"
+	Add             Op = "+"
+	Del             Op = "-"
+	RunCmd          Op = "R"
+	DestroyRoot     Op = "DESTROYROOT"
+	CreateRoot      Op = "CREATEROOT"
+)
+
+type DestroyRootOp struct {
+	Path string
+}
+
+func (o *DestroyRootOp) Run(ctx context.Context, e Execer) error {
+	const magicName = "zreplplayground"
+	// sanity check: root must contain
+	if !strings.Contains(o.Path, magicName) {
+		panic("sanity check failed")
+	}
+	// early-exit if it doesn't exist
+	if err := e.RunExpectSuccessNoOutput(ctx, "zfs", "get", "-H", "name", o.Path); err != nil {
+		getLog(ctx).WithField("root_ds", o.Path).Info("assume root ds doesn't exist")
+		return nil
+	}
+	op, err := exec.CommandContext(ctx, "zfs", "destroy", "-nvrp", o.Path).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("cannot clean root dataset %q: %s\n%s", o.Path, err, op)
+	}
+	sc := bufio.NewScanner(bytes.NewReader(op))
+	for sc.Scan() {
+		if !strings.Contains(sc.Text(), magicName) {
+			panic("sanity check failed")
+		}
+	}
+	return e.RunExpectSuccessNoOutput(ctx, "zfs", "destroy", "-r", o.Path)
+}
+
+type FSOp struct {
+	Op   Op
+	Path string
+}
+
+func (o *FSOp) Run(ctx context.Context, e Execer) error {
+	switch o.Op {
+	case AssertExists:
+		return e.RunExpectSuccessNoOutput(ctx, "zfs", "get", "-H", "name", o.Path)
+	case AssertNotExists:
+		return e.RunExpectFailureNoOutput(ctx, "zfs", "get", "-H", "name", o.Path)
+	case Add:
+		return e.RunExpectSuccessNoOutput(ctx, "zfs", "create", o.Path)
+	case Del:
+		return e.RunExpectSuccessNoOutput(ctx, "zfs", "destroy", o.Path)
+	default:
+		panic(o.Op)
+	}
+}
+
+type SnapOp struct {
+	Op   Op
+	Path string
+}
+
+func (o *SnapOp) Run(ctx context.Context, e Execer) error {
+	switch o.Op {
+	case AssertExists:
+		return e.RunExpectSuccessNoOutput(ctx, "zfs", "get", "-H", "name", o.Path)
+	case AssertNotExists:
+		return e.RunExpectFailureNoOutput(ctx, "zfs", "get", "-H", "name", o.Path)
+	case Add:
+		return e.RunExpectSuccessNoOutput(ctx, "zfs", "snapshot", o.Path)
+	case Del:
+		return e.RunExpectSuccessNoOutput(ctx, "zfs", "destroy", o.Path)
+	default:
+		panic(o.Op)
+	}
+}
+
+type RunOp struct {
+	RootDS string
+	Script string
+}
+
+func (o *RunOp) Run(ctx context.Context, e Execer) error {
+	cmd := exec.CommandContext(ctx, "/usr/bin/env", "bash", "-c", o.Script)
+	cmd.Env = os.Environ()
+	cmd.Env = append(cmd.Env, fmt.Sprintf("ROOTDS=%s", o.RootDS))
+	log := getLog(ctx).WithField("script", o.Script)
+	log.Info("start script")
+	defer log.Info("script done")
+	output, err := cmd.CombinedOutput()
+	if _, ok := err.(*exec.ExitError); err != nil && !ok {
+		panic(err)
+	}
+	log.Printf("script output:\n%s", output)
+	return err
+}
+
+type LineError struct {
+	Line string
+	What string
+}
+
+func (e LineError) Error() string {
+	return fmt.Sprintf("%q: %s", e.Line, e.What)
+}
+
+type RunKind int
+
+const (
+	PanicErr RunKind = 1 << iota
+	RunAll
+)
+
+func Run(ctx context.Context, rk RunKind, rootds string, stmtsStr string) {
+	stmt, err := parseSequence(rootds, stmtsStr)
+	if err != nil {
+		panic(err)
+	}
+	execer := newEx(getLog(ctx))
+	for _, s := range stmt {
+		err := s.Run(ctx, execer)
+		if err == nil {
+			continue
+		}
+		if rk == PanicErr {
+			panic(err)
+		} else if rk == RunAll {
+			continue
+		} else {
+			panic(rk)
+		}
+	}
+}
+
+func isNoSpace(r rune) bool {
+	return !unicode.IsSpace(r)
+}
+
+func splitQuotedWords(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	begin := bytes.IndexFunc(data, isNoSpace)
+	if begin == -1 {
+		return len(data), nil, nil
+	}
+	if data[begin] == '"' {
+		end := begin + 1
+		for end < len(data) {
+			endCandidate := bytes.Index(data[end:], []byte(`"`))
+			if endCandidate == -1 {
+				return 0, nil, nil
+			}
+			end += endCandidate
+			if data[end-1] != '\\' {
+				// unescaped quote, end of this string
+				// remove backslash-escapes
+				withBackslash := data[begin+1 : end]
+				withoutBaskslash := bytes.Replace(withBackslash, []byte("\\\""), []byte("\""), -1)
+				return end + 1, withoutBaskslash, nil
+			} else {
+				// continue to next quote
+				end += 1
+			}
+		}
+	} else {
+		endOffset := bytes.IndexFunc(data[begin:], unicode.IsSpace)
+		var end int
+		if endOffset == -1 {
+			if !atEOF {
+				return 0, nil, nil
+			} else {
+				end = len(data)
+			}
+		} else {
+			end = begin + endOffset
+		}
+		return end, data[begin:end], nil
+	}
+	return 0, nil, fmt.Errorf("unexpected")
+}
+
+func parseSequence(rootds, stmtsStr string) (stmts []Stmt, err error) {
+	scan := bufio.NewScanner(strings.NewReader(stmtsStr))
+nextLine:
+	for scan.Scan() {
+		if len(bytes.TrimSpace(scan.Bytes())) == 0 {
+			continue
+		}
+		comps := bufio.NewScanner(bytes.NewReader(scan.Bytes()))
+		comps.Split(splitQuotedWords)
+
+		expectMoreTokens := func() error {
+			if !comps.Scan() {
+				return &LineError{scan.Text(), "unexpected EOL"}
+			}
+			return nil
+		}
+
+		// Op
+		if err := expectMoreTokens(); err != nil {
+			return nil, err
+		}
+		var op Op
+		switch comps.Text() {
+
+		case string(RunCmd):
+			script := strings.TrimPrefix(strings.TrimSpace(scan.Text()), string(RunCmd))
+			stmts = append(stmts, &RunOp{RootDS: rootds, Script: script})
+			continue nextLine
+
+		case string(DestroyRoot):
+			if comps.Scan() {
+				return nil, &LineError{scan.Text(), fmt.Sprintf("unexpected tokens at EOL")}
+			}
+			stmts = append(stmts, &DestroyRootOp{rootds})
+			continue nextLine
+
+		case string(CreateRoot):
+			if comps.Scan() {
+				return nil, &LineError{scan.Text(), fmt.Sprintf("unexpected tokens at EOL")}
+			}
+			stmts = append(stmts, &FSOp{Op: Add, Path: rootds})
+			continue nextLine
+
+		case string(Add):
+			op = Add
+		case string(Del):
+			op = Del
+		case string(AssertExists):
+			op = AssertExists
+		case string(AssertNotExists):
+			op = AssertNotExists
+		default:
+			return nil, &LineError{scan.Text(), fmt.Sprintf("invalid op %q", comps.Text())}
+		}
+
+		// FS / SNAP
+		if err := expectMoreTokens(); err != nil {
+			return nil, err
+		}
+		if strings.ContainsAny(comps.Text(), "@") {
+			stmts = append(stmts, &SnapOp{Op: op, Path: fmt.Sprintf("%s/%s", rootds, comps.Text())})
+		} else {
+			stmts = append(stmts, &FSOp{Op: op, Path: fmt.Sprintf("%s/%s", rootds, comps.Text())})
+		}
+
+		if comps.Scan() {
+			return nil, &LineError{scan.Text(), fmt.Sprintf("unexpected tokens at EOL")}
+		}
+	}
+	return stmts, nil
+}

--- a/platformtest/platformtest_parser_test.go
+++ b/platformtest/platformtest_parser_test.go
@@ -1,0 +1,33 @@
+package platformtest
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplitQuotedWords(t *testing.T) {
+	s := bufio.NewScanner(strings.NewReader(`
+	foo "bar baz" blah "foo \"with single escape" "blah baz" "\"foo" "foo\""
+	`))
+	s.Split(splitQuotedWords)
+	var words []string
+	for s.Scan() {
+		words = append(words, s.Text())
+	}
+	assert.Equal(
+		t,
+		[]string{
+			"foo",
+			"bar baz",
+			"blah",
+			"foo \"with single escape",
+			"blah baz",
+			"\"foo",
+			"foo\"",
+		},
+		words)
+
+}

--- a/platformtest/tests/batchDestroy.go
+++ b/platformtest/tests/batchDestroy.go
@@ -1,0 +1,54 @@
+package tests
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/zrepl/zrepl/platformtest"
+	"github.com/zrepl/zrepl/zfs"
+)
+
+func BatchDestroy(ctx *platformtest.Context) {
+
+	platformtest.Run(ctx, platformtest.PanicErr, ctx.RootDataset, `
+		DESTROYROOT
+		CREATEROOT
+		+  "foo bar"
+		+  "foo bar@1"
+		+  "foo bar@2"
+		+  "foo bar@3"
+		R  zfs hold zrepl_platformtest "${ROOTDS}/foo bar@2"
+	`)
+
+	reqs := []*zfs.DestroySnapOp{
+		&zfs.DestroySnapOp{
+			ErrOut:     new(error),
+			Filesystem: fmt.Sprintf("%s/foo bar", ctx.RootDataset),
+			Name:       "3",
+		},
+		&zfs.DestroySnapOp{
+			ErrOut:     new(error),
+			Filesystem: fmt.Sprintf("%s/foo bar", ctx.RootDataset),
+			Name:       "2",
+		},
+	}
+	zfs.ZFSDestroyFilesystemVersions(reqs)
+	if *reqs[0].ErrOut != nil {
+		panic("expecting no error")
+	}
+	err := (*reqs[1].ErrOut).Error()
+	if !strings.Contains(err, fmt.Sprintf("%s/foo bar@2", ctx.RootDataset)) {
+		panic(fmt.Sprintf("expecting error about being unable to destroy @2: %T\n%s", err, err))
+	}
+
+	platformtest.Run(ctx, platformtest.PanicErr, ctx.RootDataset, `
+	!N "foo bar@3"
+	!E "foo bar@1"
+	!E "foo bar@2"
+	R zfs release zrepl_platformtest "${ROOTDS}/foo bar@2"
+	-  "foo bar@2"
+	-  "foo bar@1"
+	-  "foo bar"
+	`)
+
+}

--- a/platformtest/tests/getNonexistent.go
+++ b/platformtest/tests/getNonexistent.go
@@ -1,0 +1,54 @@
+package tests
+
+import (
+	"fmt"
+
+	"github.com/zrepl/zrepl/platformtest"
+	"github.com/zrepl/zrepl/zfs"
+)
+
+func GetNonexistent(ctx *platformtest.Context) {
+
+	platformtest.Run(ctx, platformtest.PanicErr, ctx.RootDataset, `
+		DESTROYROOT
+		CREATEROOT
+		+  "foo bar"
+		+  "foo bar@1"
+	`)
+	defer platformtest.Run(ctx, platformtest.PanicErr, ctx.RootDataset, `
+		DESTROYROOT
+	`)
+
+	// test raw
+	_, err := zfs.ZFSGetRawAnySource(fmt.Sprintf("%s/foo bar", ctx.RootDataset), []string{"name"})
+	if err != nil {
+		panic(err)
+	}
+
+	// test nonexistent filesystem
+	nonexistent := fmt.Sprintf("%s/nonexistent filesystem", ctx.RootDataset)
+	props, err := zfs.ZFSGetRawAnySource(nonexistent, []string{"name"})
+	if err == nil {
+		panic(props)
+	}
+	dsne, ok := err.(*zfs.DatasetDoesNotExist)
+	if !ok {
+		panic(err)
+	} else if dsne.Path != nonexistent {
+		panic(err)
+	}
+
+	// test nonexistent snapshot
+	nonexistent = fmt.Sprintf("%s/foo bar@non existent", ctx.RootDataset)
+	props, err = zfs.ZFSGetRawAnySource(nonexistent, []string{"name"})
+	if err == nil {
+		panic(props)
+	}
+	dsne, ok = err.(*zfs.DatasetDoesNotExist)
+	if !ok {
+		panic(err)
+	} else if dsne.Path != nonexistent {
+		panic(err)
+	}
+
+}

--- a/platformtest/tests/tests.go
+++ b/platformtest/tests/tests.go
@@ -1,0 +1,20 @@
+package tests
+
+import (
+	"reflect"
+	"runtime"
+
+	"github.com/zrepl/zrepl/platformtest"
+)
+
+type Case func(*platformtest.Context)
+
+func (c Case) String() string {
+	return runtime.FuncForPC(reflect.ValueOf(c).Pointer()).Name()
+}
+
+var Cases = []Case{
+	BatchDestroy,
+	UndestroyableSnapshotParsing,
+	GetNonexistent,
+}

--- a/platformtest/tests/undestroyableSnapshotParsing.go
+++ b/platformtest/tests/undestroyableSnapshotParsing.go
@@ -1,0 +1,40 @@
+package tests
+
+import (
+	"fmt"
+
+	"github.com/stretchr/testify/require"
+	"github.com/zrepl/zrepl/platformtest"
+	"github.com/zrepl/zrepl/zfs"
+)
+
+func UndestroyableSnapshotParsing(t *platformtest.Context) {
+	platformtest.Run(t, platformtest.PanicErr, t.RootDataset, `
+		DESTROYROOT
+		CREATEROOT
+		+  "foo bar"
+		+  "foo bar@1 2 3"
+		+  "foo bar@4 5 6"
+		+  "foo bar@7 8 9"
+		R  zfs hold zrepl_platformtest "${ROOTDS}/foo bar@4 5 6"
+	`)
+	defer platformtest.Run(t, platformtest.PanicErr, t.RootDataset, `
+	R zfs release zrepl_platformtest "${ROOTDS}/foo bar@4 5 6"
+	DESTROYROOT
+	`)
+
+	err := zfs.ZFSDestroy(fmt.Sprintf("%s/foo bar@1 2 3,4 5 6,7 8 9", t.RootDataset))
+	if err == nil {
+		panic("expecting destroy error due to hold")
+	}
+	if dse, ok := err.(*zfs.DestroySnapshotsError); !ok {
+		panic(fmt.Sprintf("expecting *zfs.DestroySnapshotsError, got %T\n%v\n%s", err, err, err))
+	} else {
+		if dse.Filesystem != fmt.Sprintf("%s/foo bar", t.RootDataset) {
+			panic(dse.Filesystem)
+		}
+		require.Equal(t, []string{"4 5 6"}, dse.Undestroyable)
+		require.Equal(t, []string{"dataset is busy"}, dse.Reason)
+	}
+
+}

--- a/util/envconst/envconst.go
+++ b/util/envconst/envconst.go
@@ -25,6 +25,23 @@ func Duration(varname string, def time.Duration) time.Duration {
 	return d
 }
 
+func Int(varname string, def int) int {
+	if v, ok := cache.Load(varname); ok {
+		return v.(int)
+	}
+	e := os.Getenv(varname)
+	if e == "" {
+		return def
+	}
+	d64, err := strconv.ParseInt(e, 10, strconv.IntSize)
+	if err != nil {
+		panic(err)
+	}
+	d := int(d64)
+	cache.Store(varname, d)
+	return d
+}
+
 func Int64(varname string, def int64) int64 {
 	if v, ok := cache.Load(varname); ok {
 		return v.(int64)

--- a/zfs/versions.go
+++ b/zfs/versions.go
@@ -154,15 +154,3 @@ func ZFSListFilesystemVersions(fs *DatasetPath, filter FilesystemVersionFilter) 
 	}
 	return
 }
-
-func ZFSDestroyFilesystemVersion(filesystem *DatasetPath, version *FilesystemVersion) (err error) {
-
-	datasetPath := version.ToAbsPath(filesystem)
-
-	// Sanity check...
-	if !strings.ContainsAny(datasetPath, "@#") {
-		return fmt.Errorf("sanity check failed: no @ or # character found in %q", datasetPath)
-	}
-
-	return ZFSDestroy(datasetPath)
-}

--- a/zfs/versions_destroy.go
+++ b/zfs/versions_destroy.go
@@ -1,0 +1,234 @@
+package zfs
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"sync"
+	"syscall"
+
+	"github.com/zrepl/zrepl/util/envconst"
+)
+
+func ZFSDestroyFilesystemVersion(filesystem *DatasetPath, version *FilesystemVersion) (err error) {
+
+	datasetPath := version.ToAbsPath(filesystem)
+
+	// Sanity check...
+	if !strings.ContainsAny(datasetPath, "@#") {
+		return fmt.Errorf("sanity check failed: no @ or # character found in %q", datasetPath)
+	}
+
+	return ZFSDestroy(datasetPath)
+}
+
+var destroyerSingleton = destroyerImpl{}
+
+type DestroySnapOp struct {
+	Filesystem string
+	Name       string
+	ErrOut     *error
+}
+
+func (o *DestroySnapOp) String() string {
+	return fmt.Sprintf("destroy operation %s@%s", o.Filesystem, o.Name)
+}
+
+func ZFSDestroyFilesystemVersions(reqs []*DestroySnapOp) {
+	doDestroy(context.TODO(), reqs, destroyerSingleton)
+}
+
+func setDestroySnapOpErr(b []*DestroySnapOp, err error) {
+	for _, r := range b {
+		*r.ErrOut = err
+	}
+}
+
+type destroyer interface {
+	Destroy(args []string) error
+	DestroySnapshotsCommaSyntaxSupported() (bool, error)
+}
+
+func doDestroy(ctx context.Context, reqs []*DestroySnapOp, e destroyer) {
+
+	var validated []*DestroySnapOp
+	for _, req := range reqs {
+		// Filesystem and Snapshot should not be empty
+		// ZFS will generally fail because those are invalid destroy arguments,
+		// but we'd rather apply defensive programming here (doing destroy after all)
+		if req.Filesystem == "" {
+			*req.ErrOut = fmt.Errorf("Filesystem must not be an empty string")
+		} else if req.Name == "" {
+			*req.ErrOut = fmt.Errorf("Name must not be an empty string")
+		} else {
+			validated = append(validated, req)
+		}
+	}
+	reqs = validated
+
+	commaSupported, err := e.DestroySnapshotsCommaSyntaxSupported()
+	if err != nil {
+		debug("destroy: comma syntax support detection failed: %s", err)
+		setDestroySnapOpErr(reqs, err)
+		return
+	}
+
+	if !commaSupported {
+		doDestroySeq(ctx, reqs, e)
+	} else {
+		doDestroyBatched(ctx, reqs, e)
+	}
+}
+
+func doDestroySeq(ctx context.Context, reqs []*DestroySnapOp, e destroyer) {
+	for _, r := range reqs {
+		*r.ErrOut = e.Destroy([]string{fmt.Sprintf("%s@%s", r.Filesystem, r.Name)})
+	}
+}
+
+func doDestroyBatched(ctx context.Context, reqs []*DestroySnapOp, d destroyer) {
+	perFS := buildBatches(reqs)
+	for _, fsbatch := range perFS {
+		doDestroyBatchedRec(ctx, fsbatch, d)
+	}
+}
+
+func buildBatches(reqs []*DestroySnapOp) [][]*DestroySnapOp {
+	if len(reqs) == 0 {
+		return nil
+	}
+	sorted := make([]*DestroySnapOp, len(reqs))
+	copy(sorted, reqs)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		// by filesystem, then snap name
+		fscmp := strings.Compare(sorted[i].Filesystem, sorted[j].Filesystem)
+		if fscmp != 0 {
+			return fscmp == -1
+		}
+		return strings.Compare(sorted[i].Name, sorted[j].Name) == -1
+	})
+
+	// group by fs
+	var perFS [][]*DestroySnapOp
+	consumed := 0
+	for consumed < len(sorted) {
+		batchConsumedUntil := consumed
+		for ; batchConsumedUntil < len(sorted) && sorted[batchConsumedUntil].Filesystem == sorted[consumed].Filesystem; batchConsumedUntil++ {
+		}
+		perFS = append(perFS, sorted[consumed:batchConsumedUntil])
+		consumed = batchConsumedUntil
+	}
+	return perFS
+}
+
+// batch must be on same Filesystem, panics otherwise
+func tryBatch(ctx context.Context, batch []*DestroySnapOp, d destroyer) error {
+	batchFS := batch[0].Filesystem
+	batchNames := make([]string, len(batch))
+	for i := range batchNames {
+		batchNames[i] = batch[i].Name
+		if batchFS != batch[i].Filesystem {
+			panic("inconsistent batch")
+		}
+	}
+	batchArg := fmt.Sprintf("%s@%s", batchFS, strings.Join(batchNames, ","))
+	return d.Destroy([]string{batchArg})
+}
+
+// fsbatch must be on same filesystem
+func doDestroyBatchedRec(ctx context.Context, fsbatch []*DestroySnapOp, d destroyer) {
+	if len(fsbatch) <= 1 {
+		doDestroySeq(ctx, fsbatch, d)
+		return
+	}
+
+	err := tryBatch(ctx, fsbatch, d)
+	if err == nil {
+		setDestroySnapOpErr(fsbatch, nil)
+		return
+	}
+
+	if pe, ok := err.(*os.PathError); ok && pe.Err == syscall.E2BIG {
+		// see TestExcessiveArgumentsResultInE2BIG
+		// try halving batch size, assuming snapshots names are roughly the same length
+		debug("batch destroy: E2BIG encountered: %s", err)
+		doDestroyBatchedRec(ctx, fsbatch[0:len(fsbatch)/2], d)
+		doDestroyBatchedRec(ctx, fsbatch[len(fsbatch)/2:], d)
+		return
+	}
+
+	singleRun := fsbatch // the destroys that will be tried sequentially after "smart" error handling below
+
+	if err, ok := err.(*DestroySnapshotsError); ok {
+		// eliminate undestroyable datasets from batch and try it once again
+		strippedBatch, remaining := make([]*DestroySnapOp, 0, len(fsbatch)), make([]*DestroySnapOp, 0, len(fsbatch))
+
+		for _, b := range fsbatch {
+			isUndestroyable := false
+			for _, undestroyable := range err.Undestroyable {
+				if undestroyable == b.Name {
+					isUndestroyable = true
+					break
+				}
+			}
+			if isUndestroyable {
+				remaining = append(remaining, b)
+			} else {
+				strippedBatch = append(strippedBatch, b)
+			}
+		}
+
+		err := tryBatch(ctx, strippedBatch, d)
+		if err != nil {
+			// run entire batch sequentially if the stripped one fails
+			// (it shouldn't because we stripped erronous datasets)
+			singleRun = fsbatch // shadow
+		} else {
+			setDestroySnapOpErr(strippedBatch, nil) // these ones worked
+			singleRun = remaining                   // shadow
+		}
+		// fallthrough
+	}
+
+	doDestroySeq(ctx, singleRun, d)
+
+}
+
+type destroyerImpl struct{}
+
+func (d destroyerImpl) Destroy(args []string) error {
+	if len(args) != 1 {
+		// we have no use case for this at the moment, so let's crash (safer than destroying something unexpectedly)
+		panic(fmt.Sprintf("unexpected number of arguments: %v", args))
+	}
+	// we know that we are only using this for snapshots, so also sanity check for an @ in args[0]
+	if !strings.ContainsAny(args[0], "@") {
+		panic(fmt.Sprintf("sanity check: expecting '@' in call to Destroy, got %q", args[0]))
+	}
+	return ZFSDestroy(args[0])
+}
+
+var batchDestroyFeatureCheck struct {
+	once   sync.Once
+	enable bool
+	err    error
+}
+
+func (d destroyerImpl) DestroySnapshotsCommaSyntaxSupported() (bool, error) {
+	batchDestroyFeatureCheck.once.Do(func() {
+		// "feature discovery"
+		cmd := exec.Command("zfs", "destroy")
+		output, err := cmd.CombinedOutput()
+		if _, ok := err.(*exec.ExitError); !ok {
+			debug("destroy feature check failed: %T %s", err, err)
+			batchDestroyFeatureCheck.err = err
+		}
+		def := strings.Contains(string(output), "<filesystem|volume>@<snap>[%<snap>][,...]")
+		batchDestroyFeatureCheck.enable = envconst.Bool("ZREPL_EXPERIMENTAL_ZFS_COMMA_SYNTAX_SUPPORTED", def)
+		debug("destroy feature check complete %#v", &batchDestroyFeatureCheck)
+	})
+	return batchDestroyFeatureCheck.enable, batchDestroyFeatureCheck.err
+}

--- a/zfs/versions_destroy_test.go
+++ b/zfs/versions_destroy_test.go
@@ -1,0 +1,248 @@
+package zfs
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/zrepl/zrepl/util/chainlock"
+)
+
+type mockBatchDestroy struct {
+	mtx              chainlock.L
+	calls            []string
+	commaUnsupported bool
+	undestroyable    string
+	randomerror      string
+	e2biglen         int
+}
+
+func (m *mockBatchDestroy) DestroySnapshotsCommaSyntaxSupported() (bool, error) {
+	return !m.commaUnsupported, nil
+}
+
+func (m *mockBatchDestroy) Destroy(args []string) error {
+	defer m.mtx.Lock().Unlock()
+	if len(args) != 1 {
+		panic("unexpected use of Destroy")
+	}
+	a := args[0]
+	if m.e2biglen > 0 && len(a) > m.e2biglen {
+		return &os.PathError{Err: syscall.E2BIG} // TestExcessiveArgumentsResultInE2BIG checks that this errors is produced
+	}
+	m.calls = append(m.calls, a)
+	if m.commaUnsupported {
+		if strings.Contains(a, ",") {
+			return fmt.Errorf("unsupported syntax mock error")
+		}
+	}
+
+	if m.undestroyable != "" && strings.Contains(a, m.undestroyable) {
+		return &DestroySnapshotsError{
+			Filesystem:    "PLACEHOLDER",
+			Undestroyable: []string{m.undestroyable},
+			Reason:        []string{"undestroyable reason"},
+		}
+	}
+	if m.randomerror != "" && strings.Contains(a, m.randomerror) {
+		return fmt.Errorf("randomerror")
+	}
+	return nil
+}
+
+func TestBatchDestroySnaps(t *testing.T) {
+
+	errs := make([]error, 10)
+	nilErrs := func() {
+		for i := range errs {
+			errs[i] = nil
+		}
+	}
+	opsTemplate := []*DestroySnapOp{
+		&DestroySnapOp{"zroot/z", "foo", &errs[0]},
+		&DestroySnapOp{"zroot/a", "foo", &errs[1]},
+		&DestroySnapOp{"zroot/a", "bar", &errs[2]},
+		&DestroySnapOp{"zroot/b", "bar", &errs[3]},
+		&DestroySnapOp{"zroot/b", "zab", &errs[4]},
+		&DestroySnapOp{"zroot/b", "undestroyable", &errs[5]},
+		&DestroySnapOp{"zroot/c", "baz", &errs[6]},
+		&DestroySnapOp{"zroot/c", "randomerror", &errs[7]},
+		&DestroySnapOp{"zroot/c", "bar", &errs[8]},
+		&DestroySnapOp{"zroot/d", "blup", &errs[9]},
+	}
+
+	t.Run("single_undestroyable_dataset", func(t *testing.T) {
+		nilErrs()
+		mock := &mockBatchDestroy{
+			commaUnsupported: false,
+			undestroyable:    "undestroyable",
+			randomerror:      "randomerror",
+		}
+
+		doDestroy(context.TODO(), opsTemplate, mock)
+
+		assert.NoError(t, errs[0])
+		assert.NoError(t, errs[1])
+		assert.NoError(t, errs[2])
+		assert.NoError(t, errs[3])
+		assert.NoError(t, errs[4])
+		assert.Error(t, errs[5], "undestroyable")
+		assert.NoError(t, errs[6])
+		assert.Error(t, errs[7], "randomerror")
+		assert.NoError(t, errs[8])
+		assert.NoError(t, errs[9])
+
+		defer mock.mtx.Lock().Unlock()
+		assert.Equal(
+			t,
+			[]string{
+				"zroot/a@bar,foo", // reordered snaps in lexicographical order
+				"zroot/b@bar,undestroyable,zab",
+				"zroot/b@bar,zab", // eliminate undestroyables, try others again
+				"zroot/b@undestroyable",
+				"zroot/c@bar,baz,randomerror",
+				"zroot/c@bar", // fallback to single-snapshot on non DestroyError
+				"zroot/c@baz",
+				"zroot/c@randomerror",
+				"zroot/d@blup",
+				"zroot/z@foo", // ordered at last position
+			},
+			mock.calls,
+		)
+	})
+
+	t.Run("comma_syntax_unsupported", func(t *testing.T) {
+		nilErrs()
+		mock := &mockBatchDestroy{
+			commaUnsupported: true,
+			undestroyable:    "undestroyable",
+			randomerror:      "randomerror",
+		}
+
+		doDestroy(context.TODO(), opsTemplate, mock)
+
+		assert.NoError(t, errs[0])
+		assert.NoError(t, errs[1])
+		assert.NoError(t, errs[2])
+		assert.NoError(t, errs[3])
+		assert.NoError(t, errs[4])
+		assert.Error(t, errs[5], "undestroyable")
+		assert.NoError(t, errs[6])
+		assert.Error(t, errs[7], "randomerror")
+		assert.NoError(t, errs[8])
+		assert.NoError(t, errs[9])
+
+		defer mock.mtx.Lock().Unlock()
+		assert.Equal(
+			t,
+			[]string{
+				// expect exactly argument order
+				"zroot/z@foo",
+				"zroot/a@foo",
+				"zroot/a@bar",
+				"zroot/b@bar",
+				"zroot/b@zab",
+				"zroot/b@undestroyable",
+				"zroot/c@baz",
+				"zroot/c@randomerror",
+				"zroot/c@bar",
+				"zroot/d@blup",
+			},
+			mock.calls,
+		)
+	})
+
+	t.Run("empty_ops", func(t *testing.T) {
+		mock := &mockBatchDestroy{}
+		doDestroy(context.TODO(), nil, mock)
+		defer mock.mtx.Lock().Unlock()
+		assert.Empty(t, mock.calls)
+	})
+
+	t.Run("ops_without_snapnames", func(t *testing.T) {
+		mock := &mockBatchDestroy{}
+		var err error
+		ops := []*DestroySnapOp{&DestroySnapOp{"somefs", "", &err}}
+		doDestroy(context.TODO(), ops, mock)
+		assert.Error(t, err)
+		defer mock.mtx.Lock().Unlock()
+		assert.Empty(t, mock.calls)
+	})
+
+	t.Run("ops_without_fsnames", func(t *testing.T) {
+		mock := &mockBatchDestroy{}
+		var err error
+		ops := []*DestroySnapOp{&DestroySnapOp{"", "fsname", &err}}
+		doDestroy(context.TODO(), ops, mock)
+		assert.Error(t, err)
+		defer mock.mtx.Lock().Unlock()
+		assert.Empty(t, mock.calls)
+	})
+
+	t.Run("splits_up_batches_at_e2big", func(t *testing.T) {
+		mock := &mockBatchDestroy{
+			e2biglen: 10,
+		}
+
+		var dummy error
+		reqs := []*DestroySnapOp{
+			// should fit (1111@a,b,c)
+			&DestroySnapOp{"1111", "a", &dummy},
+			&DestroySnapOp{"1111", "b", &dummy},
+			&DestroySnapOp{"1111", "c", &dummy},
+
+			// should split
+			&DestroySnapOp{"2222", "01", &dummy},
+			&DestroySnapOp{"2222", "02", &dummy},
+			&DestroySnapOp{"2222", "03", &dummy},
+			&DestroySnapOp{"2222", "04", &dummy},
+			&DestroySnapOp{"2222", "05", &dummy},
+			&DestroySnapOp{"2222", "06", &dummy},
+			&DestroySnapOp{"2222", "07", &dummy},
+			&DestroySnapOp{"2222", "08", &dummy},
+			&DestroySnapOp{"2222", "09", &dummy},
+			&DestroySnapOp{"2222", "10", &dummy},
+		}
+
+		doDestroy(context.TODO(), reqs, mock)
+
+		defer mock.mtx.Lock().Unlock()
+		assert.Equal(
+			t,
+			[]string{
+				"1111@a,b,c",
+				"2222@01,02",
+				"2222@03",
+				"2222@04,05",
+				"2222@06,07",
+				"2222@08",
+				"2222@09,10",
+			},
+			mock.calls,
+		)
+
+	})
+
+}
+
+func TestExcessiveArgumentsResultInE2BIG(t *testing.T) {
+	// FIXME dynamic value
+	const maxArgumentLength = 1 << 20 // higher than any OS we know, should always fail
+	t.Logf("maxArgumentLength=%v", maxArgumentLength)
+	maxArg := bytes.Repeat([]byte("a"), maxArgumentLength)
+	cmd := exec.Command("/bin/sh", "-c", "echo -n $1; echo -n $2", "cmdname", string(maxArg), string(maxArg))
+	output, err := cmd.CombinedOutput()
+	if pe, ok := err.(*os.PathError); ok && pe.Err == syscall.E2BIG {
+		t.Logf("ok, system returns E2BIG")
+	} else {
+		t.Errorf("system did not return E2BIG, but err=%T: %v ", err, err)
+		t.Logf("output:\n%s", output)
+	}
+}

--- a/zfs/zfs.go
+++ b/zfs/zfs.go
@@ -925,7 +925,11 @@ func ZFSGet(fs *DatasetPath, props []string) (*ZFSProperties, error) {
 	return zfsGet(fs.ToString(), props, sourceAny)
 }
 
-var zfsGetDatasetDoesNotExistRegexp = regexp.MustCompile(`^cannot open '([^)]+)': (dataset does not exist|no such pool or dataset)`)
+func ZFSGetRawAnySource(path string, props []string) (*ZFSProperties, error) {
+	return zfsGet(path, props, sourceAny)
+}
+
+var zfsGetDatasetDoesNotExistRegexp = regexp.MustCompile(`^cannot open '([^)]+)': (dataset does not exist|no such pool or dataset)`) // TODO verify this works
 
 type DatasetDoesNotExist struct {
 	Path string


### PR DESCRIPTION
(This PR is based on top of the go modules PR, merge that one first)

- [x] Tested on my personal FreeBSD 12.0 system (which supports the comma syntax)
- [x] Tested on a system that does not support comma syntax
- [x] E2BIG handling tested in practice
- [x] Undestroyable dasets in batch tested in practice
- [x] ~~Notice to package maintainers about platform tests (README.md, Installation.rst, Changelog)~~ Carried over to #211