### PR TITLE
Fix invalid comment syntax

### DIFF
--- a/dist/systemd/zrepl.service
+++ b/dist/systemd/zrepl.service
@@ -21,8 +21,10 @@ RestrictRealtime=yes
 SystemCallArchitectures=native
 
 # BEGIN ProtectHome
-ProtectHome=read-only   # DEBIAN STRETCH
-# ProtectHome=tmpfs     # FEDORA 28 / 29
+# DEBIAN STRETCH
+ProtectHome=read-only
+# FEDORA 28 / 29
+# ProtectHome=tmpfs
 # END ProtectHome
 
 # BEGIN SystemCallFilter


### PR DESCRIPTION
`systemd` can not parse the `ProtectHome` setting:
```
journalctl -u zrepl -p err
-- Logs begin at Sat 2019-08-24 03:04:22 CEST, end at Sun 2019-10-06 13:21:35 CEST. --
Okt 05 19:30:01 pidsley systemd[1]: /etc/systemd/system/zrepl.service:21: Failed to parse protect home value, ignoring: read-only   # DEBIAN STRETCH

sudo systemctl show zrepl|grep ^ProtectHome
ProtectHome=no
```


I just removed the trailing comment. I hope his meets your requirements:
Both `Stretch` and `Fedora 28` are outdated. 
Both settings work fine on my Arch Linux setup.
  