### PR TITLE
Add OmniOS (illumos distribution) to list of OSs

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -49,6 +49,9 @@ The following list may be incomplete, feel free to submit a PR with an update:
     * - Debian + Ubuntu
       - ``apt install zrepl``
       - APT repository config :ref:`see below <installation-apt-repos>`
+    * - OmniOS
+      - ``pkg install zrepl``
+      - Available since `r151030 <https://pkg.omniosce.org/r151030/extra/en/search.shtml?token=zrepl&action=Search>`_
     * - Others
       -
       - Use `binary releases`_ or build from source.


### PR DESCRIPTION
A native `zrepl` package was recently added to [OmniOS](https://omnios.org) (an illumos distribution). It is currently built with Go 1.12, the Solaris arch and a few patches. In the future, it will move to Go 1.13 and the illumos arch.

Build recipe is here: https://github.com/omniosorg/omnios-extra/tree/master/build/zrepl