### PR TITLE
Go 1.13.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,17 +34,17 @@ matrix:
       - make artifacts/zrepl-linux-amd64
       - make artifacts/zrepl-darwin-amd64
     go:
-    - "1.11"
+    - "1.11.x"
 
   - <<: *zrepl_build_template
     go:
-    - "1.12"
+    - "1.13.x"
 
   - <<: *zrepl_build_template
     go:
     - "master"
 
-  - &zrepl_docs_template 
+  - &zrepl_docs_template
     language: python
     python:
     - "3.4"
@@ -62,7 +62,7 @@ matrix:
   - <<: *zrepl_docs_template
     python:
     - "3.7"
-  
+
 
   allow_failures:
   - <<: *zrepl_build_template

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zrepl/zrepl
 
-go 1.12
+go 1.13
 
 require (
 	github.com/fatih/color v1.7.0
@@ -14,8 +14,6 @@ require (
 	github.com/lib/pq v1.2.0
 	github.com/mattn/go-colorable v0.1.4 // indirect
 	github.com/mattn/go-isatty v0.0.8
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // // go1.12 mod tidy adds this dependency as 'indirect', but go1.13 mod tidy removes it if the trailing comment is 'indirect' => add this comment to make the build work without changing go.mod on both go1.12 and go1.13
-	github.com/modern-go/reflect2 v1.0.1 // go1.12 mod tidy adds this dependency as 'indirect', but go1.13 mod tidy removes it if the trailing comment is 'indirect' => add this comment to make the build work without changing go.mod on both go1.12 and go1.13
 	github.com/montanaflynn/stats v0.5.0
 	github.com/onsi/ginkgo v1.10.2 // indirect
 	github.com/onsi/gomega v1.7.0 // indirect
@@ -23,12 +21,11 @@ require (
 	github.com/pkg/profile v1.2.1
 	github.com/problame/go-netssh v0.0.0-20191026123024-f34099f4f6b1
 	github.com/prometheus/client_golang v1.2.1
-	github.com/sergi/go-diff v1.0.1-0.20180205163309-da645544ed44 // go1.12 thinks it needs this
+	github.com/sergi/go-diff v1.0.1-0.20180205163309-da645544ed44 // indirect; go1.12 thinks it needs this
 	github.com/spf13/cobra v0.0.2
 	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.4.0
 	github.com/yudai/gojsondiff v0.0.0-20170107030110-7b1b7adf999d
-	github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82 // go1.12 thinks it needs this
 	github.com/zrepl/yaml-config v0.0.0-20190928121844-af7ca3f8448f
 	golang.org/x/net v0.0.0-20190613194153-d28f0bde5980
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58


### PR DESCRIPTION
Relates to https://github.com/Homebrew/homebrew-core/pull/47003

Upgrade the repo to use latest go v1.13.4