### PR TITLE
daemon/job/build_jobs: fix validateReceivingSidesDoNotOverlap

### DIFF
--- a/daemon/job/build_jobs.go
+++ b/daemon/job/build_jobs.go
@@ -104,6 +104,11 @@ func validateReceivingSidesDoNotOverlap(receivingRootFSs []string) error {
 	sort.Slice(rfss, func(i, j int) bool {
 		return strings.Compare(rfss[i], rfss[j]) == -1
 	})
+	// add tailing slash because of hierarchy-simulation
+	// rootfs/ is not root of rootfs2/
+	for i := 0; i < len(rfss); i++ {
+		rfss[i] += "/"
+	}
 	// idea:
 	//   no path in rfss must be prefix of another
 	//

--- a/daemon/job/build_jobs_test.go
+++ b/daemon/job/build_jobs_test.go
@@ -18,6 +18,7 @@ func TestValidateReceivingSidesDoNotOverlap(t *testing.T) {
 		{false, []string{"a"}},
 		{false, []string{"some/path"}},
 		{false, []string{"zroot/sink1", "zroot/sink2", "zroot/sink3"}},
+		{false, []string{"zroot/foo", "zroot/foobar"}},
 		{true, []string{"zroot/b", "zroot/b"}},
 		{true, []string{"zroot/foo", "zroot/foo/bar", "zroot/baz"}},
 		{false, []string{"a/x", "b/x"}},


### PR DESCRIPTION
Before this was false positiv interpreted as overlapping filesystem.
```
zpool/foo
zpool/foobar
```
This PR fixes this and marks it as non-overlapping.

- [x] Fix receiving sides not overlapping check
- [x] Add test for this
