### PR TITLE
zfs: use exec.CommandContext everywhere

### DIFF
--- a/client/migrate.go
+++ b/client/migrate.go
@@ -99,7 +99,7 @@ func doMigratePlaceholder0_1(sc *cli.Subcommand, args []string) error {
 		}
 		for _, fs := range wi.fss {
 			fmt.Printf("\t%q ... ", fs.ToString())
-			r, err := zfs.ZFSMigrateHashBasedPlaceholderToCurrent(fs, migratePlaceholder0_1Args.dryRun)
+			r, err := zfs.ZFSMigrateHashBasedPlaceholderToCurrent(ctx, fs, migratePlaceholder0_1Args.dryRun)
 			if err != nil {
 				fmt.Printf("error: %s\n", err)
 			} else if !r.NeedsModification {
@@ -264,7 +264,7 @@ func doMigrateReplicationCursorFS(ctx context.Context, v1CursorJobs []job.Job, f
 	if migrateReplicationCursorArgs.dryRun {
 		succ.Printf("DRY RUN\n")
 	} else {
-		if err := zfs.ZFSDestroyFilesystemVersion(fs, oldCursor); err != nil {
+		if err := zfs.ZFSDestroyFilesystemVersion(ctx, fs, oldCursor); err != nil {
 			return err
 		}
 	}

--- a/client/testcmd.go
+++ b/client/testcmd.go
@@ -49,6 +49,7 @@ func runTestFilterCmd(subcommand *cli.Subcommand, args []string) error {
 	}
 
 	conf := subcommand.Config()
+	ctx := context.Background()
 
 	var confFilter config.FilesystemsFilter
 	job, err := conf.Job(testFilterArgs.job)
@@ -75,7 +76,7 @@ func runTestFilterCmd(subcommand *cli.Subcommand, args []string) error {
 	if testFilterArgs.input != "" {
 		fsnames = []string{testFilterArgs.input}
 	} else {
-		out, err := zfs.ZFSList([]string{"name"})
+		out, err := zfs.ZFSList(ctx, []string{"name"})
 		if err != nil {
 			return fmt.Errorf("could not list ZFS filesystems: %s", err)
 		}
@@ -139,10 +140,11 @@ var testPlaceholder = &cli.Subcommand{
 func runTestPlaceholder(subcommand *cli.Subcommand, args []string) error {
 
 	var checkDPs []*zfs.DatasetPath
+	ctx := context.Background()
 
 	// all actions first
 	if testPlaceholderArgs.all {
-		out, err := zfs.ZFSList([]string{"name"})
+		out, err := zfs.ZFSList(ctx, []string{"name"})
 		if err != nil {
 			return errors.Wrap(err, "could not list ZFS filesystems")
 		}
@@ -166,7 +168,7 @@ func runTestPlaceholder(subcommand *cli.Subcommand, args []string) error {
 
 	fmt.Printf("IS_PLACEHOLDER\tDATASET\tzrepl:placeholder\n")
 	for _, dp := range checkDPs {
-		ph, err := zfs.ZFSGetFilesystemPlaceholderState(dp)
+		ph, err := zfs.ZFSGetFilesystemPlaceholderState(ctx, dp)
 		if err != nil {
 			return errors.Wrap(err, "cannot get placeholder state")
 		}

--- a/daemon/snapper/snapper.go
+++ b/daemon/snapper/snapper.go
@@ -277,7 +277,7 @@ func snapshot(a args, u updater) state {
 
 		jobCallback := hooks.NewCallbackHookForFilesystem("snapshot", fs, func(_ context.Context) (err error) {
 			l.Debug("create snapshot")
-			err = zfs.ZFSSnapshot(fs, snapname, false) // TODO propagate context to ZFSSnapshot
+			err = zfs.ZFSSnapshot(a.ctx, fs, snapname, false) // TODO propagate context to ZFSSnapshot
 			if err != nil {
 				l.WithError(err).Error("cannot create snapshot")
 			}

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -511,7 +511,7 @@ func (s *Receiver) ListFilesystems(ctx context.Context, req *pdu.ListFilesystemR
 	fss := make([]*pdu.Filesystem, 0, len(filtered))
 	for _, a := range filtered {
 		l := getLogger(ctx).WithField("fs", a)
-		ph, err := zfs.ZFSGetFilesystemPlaceholderState(a)
+		ph, err := zfs.ZFSGetFilesystemPlaceholderState(ctx, a)
 		if err != nil {
 			l.WithError(err).Error("error getting placeholder state")
 			return nil, errors.Wrapf(err, "cannot get placeholder state for fs %q", a)
@@ -637,7 +637,7 @@ func (s *Receiver) Receive(ctx context.Context, req *pdu.ReceiveReq, receive zfs
 			if v.Path.Equal(lp) {
 				return false
 			}
-			ph, err := zfs.ZFSGetFilesystemPlaceholderState(v.Path)
+			ph, err := zfs.ZFSGetFilesystemPlaceholderState(ctx, v.Path)
 			getLogger(ctx).
 				WithField("fs", v.Path.ToString()).
 				WithField("placeholder_state", fmt.Sprintf("%#v", ph)).
@@ -661,7 +661,7 @@ func (s *Receiver) Receive(ctx context.Context, req *pdu.ReceiveReq, receive zfs
 				}
 				l := getLogger(ctx).WithField("placeholder_fs", v.Path)
 				l.Debug("create placeholder filesystem")
-				err := zfs.ZFSCreatePlaceholderFilesystem(v.Path)
+				err := zfs.ZFSCreatePlaceholderFilesystem(ctx, v.Path)
 				if err != nil {
 					l.WithError(err).Error("cannot create placeholder filesystem")
 					visitErr = err
@@ -681,19 +681,19 @@ func (s *Receiver) Receive(ctx context.Context, req *pdu.ReceiveReq, receive zfs
 	// determine whether we need to rollback the filesystem / change its placeholder state
 	var clearPlaceholderProperty bool
 	var recvOpts zfs.RecvOptions
-	ph, err := zfs.ZFSGetFilesystemPlaceholderState(lp)
+	ph, err := zfs.ZFSGetFilesystemPlaceholderState(ctx, lp)
 	if err == nil && ph.FSExists && ph.IsPlaceholder {
 		recvOpts.RollbackAndForceRecv = true
 		clearPlaceholderProperty = true
 	}
 	if clearPlaceholderProperty {
-		if err := zfs.ZFSSetPlaceholder(lp, false); err != nil {
+		if err := zfs.ZFSSetPlaceholder(ctx, lp, false); err != nil {
 			return nil, fmt.Errorf("cannot clear placeholder property for forced receive: %s", err)
 		}
 	}
 
 	if req.ClearResumeToken && ph.FSExists {
-		if err := zfs.ZFSRecvClearResumeToken(lp.ToString()); err != nil {
+		if err := zfs.ZFSRecvClearResumeToken(ctx, lp.ToString()); err != nil {
 			return nil, errors.Wrap(err, "cannot clear resume token")
 		}
 	}

--- a/endpoint/endpoint_zfs.go
+++ b/endpoint/endpoint_zfs.go
@@ -170,7 +170,7 @@ func MoveReplicationCursor(ctx context.Context, fs string, target *zfs.ZFSSendAr
 	// idempotently create bookmark (guid is encoded in it, hence we'll most likely add a new one
 	// cleanup the old one afterwards
 
-	err = zfs.ZFSBookmark(fs, *target, bookmarkname)
+	err = zfs.ZFSBookmark(ctx, fs, *target, bookmarkname)
 	if err != nil {
 		if err == zfs.ErrBookmarkCloningNotSupported {
 			return nil, err // TODO go1.13 use wrapping
@@ -221,7 +221,7 @@ func HoldStep(ctx context.Context, fs string, v *zfs.ZFSSendArgVersion, jobID Jo
 		return errors.Wrap(err, "create step bookmark: determine bookmark name")
 	}
 	// idempotently create bookmark
-	err = zfs.ZFSBookmark(fs, *v, bmname)
+	err = zfs.ZFSBookmark(ctx, fs, *v, bmname)
 	if err != nil {
 		if err == zfs.ErrBookmarkCloningNotSupported {
 			// TODO we could actually try to find a local snapshot that has the requested GUID
@@ -269,7 +269,7 @@ func ReleaseStep(ctx context.Context, fs string, v *zfs.ZFSSendArgVersion, jobID
 	}
 	// idempotently destroy bookmark
 
-	if err := zfs.ZFSDestroyIdempotent(bmname); err != nil {
+	if err := zfs.ZFSDestroyIdempotent(ctx, bmname); err != nil {
 		return errors.Wrap(err, "step release: bookmark destroy: zfs")
 	}
 

--- a/endpoint/endpoint_zfs_helpers.go
+++ b/endpoint/endpoint_zfs_helpers.go
@@ -100,7 +100,7 @@ func destroyBookmarksOlderThan(ctx context.Context, fs string, mostRecent *zfs.Z
 
 	// FIXME use batch destroy, must adopt code to handle bookmarks
 	for _, v := range destroy {
-		if err := zfs.ZFSDestroyIdempotent(v.ToAbsPath(fsp)); err != nil {
+		if err := zfs.ZFSDestroyIdempotent(ctx, v.ToAbsPath(fsp)); err != nil {
 			return nil, errors.Wrap(err, "destroy bookmark")
 		}
 	}

--- a/platformtest/platformtest_zpool.go
+++ b/platformtest/platformtest_zpool.go
@@ -45,7 +45,7 @@ func CreateOrReplaceZpool(ctx context.Context, e Execer, args ZpoolCreateArgs) (
 	}
 
 	// export pool if it already exists (idempotence)
-	if _, err := zfs.ZFSGetRawAnySource(args.PoolName, []string{"name"}); err != nil {
+	if _, err := zfs.ZFSGetRawAnySource(ctx, args.PoolName, []string{"name"}); err != nil {
 		if _, ok := err.(*zfs.DatasetDoesNotExist); ok {
 			// we'll create it shortly
 		} else {

--- a/platformtest/tests/batchRelease.go
+++ b/platformtest/tests/batchRelease.go
@@ -54,7 +54,7 @@ func rollupReleaseTest(ctx *platformtest.Context, cb func(fs string) []rollupRel
 
 func RollupReleaseIncluding(ctx *platformtest.Context) {
 	rollupReleaseTest(ctx, func(fs string) []rollupReleaseExpectTags {
-		guid5, err := zfs.ZFSGetGUID(fs, "@5")
+		guid5, err := zfs.ZFSGetGUID(ctx, fs, "@5")
 		require.NoError(ctx, err)
 
 		err = zfs.ZFSReleaseAllOlderAndIncludingGUID(ctx, fs, guid5, "zrepl_platformtest")
@@ -73,7 +73,7 @@ func RollupReleaseIncluding(ctx *platformtest.Context) {
 
 func RollupReleaseExcluding(ctx *platformtest.Context) {
 	rollupReleaseTest(ctx, func(fs string) []rollupReleaseExpectTags {
-		guid5, err := zfs.ZFSGetGUID(fs, "@5")
+		guid5, err := zfs.ZFSGetGUID(ctx, fs, "@5")
 		require.NoError(ctx, err)
 
 		err = zfs.ZFSReleaseAllOlderThanGUID(ctx, fs, guid5, "zrepl_platformtest")
@@ -92,13 +92,13 @@ func RollupReleaseExcluding(ctx *platformtest.Context) {
 
 func RollupReleaseMostRecentIsBookmarkWithoutSnapshot(ctx *platformtest.Context) {
 	rollupReleaseTest(ctx, func(fs string) []rollupReleaseExpectTags {
-		guid5, err := zfs.ZFSGetGUID(fs, "#5")
+		guid5, err := zfs.ZFSGetGUID(ctx, fs, "#5")
 		require.NoError(ctx, err)
 
 		err = zfs.ZFSRelease(ctx, "zrepl_platformtest", fs+"@5")
 		require.NoError(ctx, err)
 
-		err = zfs.ZFSDestroy(fs + "@5")
+		err = zfs.ZFSDestroy(ctx, fs+"@5")
 		require.NoError(ctx, err)
 
 		err = zfs.ZFSReleaseAllOlderAndIncludingGUID(ctx, fs, guid5, "zrepl_platformtest")
@@ -117,7 +117,7 @@ func RollupReleaseMostRecentIsBookmarkWithoutSnapshot(ctx *platformtest.Context)
 
 func RollupReleaseMostRecentIsBookmarkAndSnapshotStillExists(ctx *platformtest.Context) {
 	rollupReleaseTest(ctx, func(fs string) []rollupReleaseExpectTags {
-		guid5, err := zfs.ZFSGetGUID(fs, "#5")
+		guid5, err := zfs.ZFSGetGUID(ctx, fs, "#5")
 		require.NoError(ctx, err)
 
 		err = zfs.ZFSReleaseAllOlderAndIncludingGUID(ctx, fs, guid5, "zrepl_platformtest")

--- a/platformtest/tests/getNonexistent.go
+++ b/platformtest/tests/getNonexistent.go
@@ -17,14 +17,14 @@ func GetNonexistent(ctx *platformtest.Context) {
 	`)
 
 	// test raw
-	_, err := zfs.ZFSGetRawAnySource(fmt.Sprintf("%s/foo bar", ctx.RootDataset), []string{"name"})
+	_, err := zfs.ZFSGetRawAnySource(ctx, fmt.Sprintf("%s/foo bar", ctx.RootDataset), []string{"name"})
 	if err != nil {
 		panic(err)
 	}
 
 	// test nonexistent filesystem
 	nonexistent := fmt.Sprintf("%s/nonexistent filesystem", ctx.RootDataset)
-	props, err := zfs.ZFSGetRawAnySource(nonexistent, []string{"name"})
+	props, err := zfs.ZFSGetRawAnySource(ctx, nonexistent, []string{"name"})
 	if err == nil {
 		panic(props)
 	}
@@ -37,7 +37,7 @@ func GetNonexistent(ctx *platformtest.Context) {
 
 	// test nonexistent snapshot
 	nonexistent = fmt.Sprintf("%s/foo bar@non existent", ctx.RootDataset)
-	props, err = zfs.ZFSGetRawAnySource(nonexistent, []string{"name"})
+	props, err = zfs.ZFSGetRawAnySource(ctx, nonexistent, []string{"name"})
 	if err == nil {
 		panic(props)
 	}
@@ -50,7 +50,7 @@ func GetNonexistent(ctx *platformtest.Context) {
 
 	// test nonexistent bookmark
 	nonexistent = fmt.Sprintf("%s/foo bar#non existent", ctx.RootDataset)
-	props, err = zfs.ZFSGetRawAnySource(nonexistent, []string{"name"})
+	props, err = zfs.ZFSGetRawAnySource(ctx, nonexistent, []string{"name"})
 	if err == nil {
 		panic(props)
 	}

--- a/platformtest/tests/helpers.go
+++ b/platformtest/tests/helpers.go
@@ -14,8 +14,8 @@ import (
 	"github.com/zrepl/zrepl/zfs"
 )
 
-func sendArgVersion(fs, relName string) zfs.ZFSSendArgVersion {
-	guid, err := zfs.ZFSGetGUID(fs, relName)
+func sendArgVersion(ctx *platformtest.Context, fs, relName string) zfs.ZFSSendArgVersion {
+	guid, err := zfs.ZFSGetGUID(ctx, fs, relName)
 	if err != nil {
 		panic(err)
 	}
@@ -33,7 +33,7 @@ func mustDatasetPath(fs string) *zfs.DatasetPath {
 	return p
 }
 
-func mustSnapshot(snap string) {
+func mustSnapshot(ctx *platformtest.Context, snap string) {
 	if err := zfs.EntityNamecheck(snap, zfs.EntityTypeSnapshot); err != nil {
 		panic(err)
 	}
@@ -41,14 +41,14 @@ func mustSnapshot(snap string) {
 	if len(comps) != 2 {
 		panic(comps)
 	}
-	err := zfs.ZFSSnapshot(mustDatasetPath(comps[0]), comps[1], false)
+	err := zfs.ZFSSnapshot(ctx, mustDatasetPath(comps[0]), comps[1], false)
 	if err != nil {
 		panic(err)
 	}
 }
 
-func mustGetProps(entity string) zfs.ZFSPropCreateTxgAndGuidProps {
-	props, err := zfs.ZFSGetCreateTXGAndGuid(entity)
+func mustGetProps(ctx *platformtest.Context, entity string) zfs.ZFSPropCreateTxgAndGuidProps {
+	props, err := zfs.ZFSGetCreateTXGAndGuid(ctx, entity)
 	check(err)
 	return props
 }
@@ -87,7 +87,7 @@ type resumeSituation struct {
 func makeDummyDataSnapshots(ctx *platformtest.Context, sendFS string) (situation dummySnapshotSituation) {
 
 	situation.sendFS = sendFS
-	sendFSMount, err := zfs.ZFSGetMountpoint(sendFS)
+	sendFSMount, err := zfs.ZFSGetMountpoint(ctx, sendFS)
 	require.NoError(ctx, err)
 	require.True(ctx, sendFSMount.Mounted)
 
@@ -95,13 +95,13 @@ func makeDummyDataSnapshots(ctx *platformtest.Context, sendFS string) (situation
 	situation.dummyDataLen = dummyLen
 
 	writeDummyData(path.Join(sendFSMount.Mountpoint, "dummy_data"), dummyLen)
-	mustSnapshot(sendFS + "@a snapshot")
-	snapA := sendArgVersion(sendFS, "@a snapshot")
+	mustSnapshot(ctx, sendFS+"@a snapshot")
+	snapA := sendArgVersion(ctx, sendFS, "@a snapshot")
 	situation.snapA = &snapA
 
 	writeDummyData(path.Join(sendFSMount.Mountpoint, "dummy_data"), dummyLen)
-	mustSnapshot(sendFS + "@b snapshot")
-	snapB := sendArgVersion(sendFS, "@b snapshot")
+	mustSnapshot(ctx, sendFS+"@b snapshot")
+	snapB := sendArgVersion(ctx, sendFS, "@b snapshot")
 	situation.snapB = &snapB
 
 	return situation

--- a/platformtest/tests/idempotentBookmark.go
+++ b/platformtest/tests/idempotentBookmark.go
@@ -19,22 +19,22 @@ func IdempotentBookmark(ctx *platformtest.Context) {
 
 	fs := fmt.Sprintf("%s/foo bar", ctx.RootDataset)
 
-	asnap := sendArgVersion(fs, "@a snap")
-	anotherSnap := sendArgVersion(fs, "@another snap")
+	asnap := sendArgVersion(ctx, fs, "@a snap")
+	anotherSnap := sendArgVersion(ctx, fs, "@another snap")
 
-	err := zfs.ZFSBookmark(fs, asnap, "a bookmark")
+	err := zfs.ZFSBookmark(ctx, fs, asnap, "a bookmark")
 	if err != nil {
 		panic(err)
 	}
 
 	// do it again, should be idempotent
-	err = zfs.ZFSBookmark(fs, asnap, "a bookmark")
+	err = zfs.ZFSBookmark(ctx, fs, asnap, "a bookmark")
 	if err != nil {
 		panic(err)
 	}
 
 	// should fail for another snapshot
-	err = zfs.ZFSBookmark(fs, anotherSnap, "a bookmark")
+	err = zfs.ZFSBookmark(ctx, fs, anotherSnap, "a bookmark")
 	if err == nil {
 		panic(err)
 	}
@@ -43,12 +43,12 @@ func IdempotentBookmark(ctx *platformtest.Context) {
 	}
 
 	// destroy the snapshot
-	if err := zfs.ZFSDestroy(fmt.Sprintf("%s@a snap", fs)); err != nil {
+	if err := zfs.ZFSDestroy(ctx, fmt.Sprintf("%s@a snap", fs)); err != nil {
 		panic(err)
 	}
 
 	// do it again, should fail with special error type
-	err = zfs.ZFSBookmark(fs, asnap, "a bookmark")
+	err = zfs.ZFSBookmark(ctx, fs, asnap, "a bookmark")
 	if err == nil {
 		panic(err)
 	}

--- a/platformtest/tests/idempotentDestroy.go
+++ b/platformtest/tests/idempotentDestroy.go
@@ -18,8 +18,8 @@ func IdempotentDestroy(ctx *platformtest.Context) {
 	`)
 
 	fs := fmt.Sprintf("%s/foo bar", ctx.RootDataset)
-	asnap := sendArgVersion(fs, "@a snap")
-	err := zfs.ZFSBookmark(fs, asnap, "a bookmark")
+	asnap := sendArgVersion(ctx, fs, "@a snap")
+	err := zfs.ZFSBookmark(ctx, fs, asnap, "a bookmark")
 	if err != nil {
 		panic(err)
 	}
@@ -41,17 +41,17 @@ func IdempotentDestroy(ctx *platformtest.Context) {
 			log.Printf("SUBBEGIN testing idempotent destroy %q for path %q", c.description, c.path)
 
 			log.Println("destroy existing")
-			err = zfs.ZFSDestroy(c.path)
+			err = zfs.ZFSDestroy(ctx, c.path)
 			if err != nil {
 				panic(err)
 			}
 			log.Println("destroy again, non-idempotently, must error")
-			err = zfs.ZFSDestroy(c.path)
+			err = zfs.ZFSDestroy(ctx, c.path)
 			if _, ok := err.(*zfs.DatasetDoesNotExist); !ok {
 				panic(fmt.Sprintf("%T: %s", err, err))
 			}
 			log.Println("destroy again, idempotently, must not error")
-			err = zfs.ZFSDestroyIdempotent(c.path)
+			err = zfs.ZFSDestroyIdempotent(ctx, c.path)
 			if err != nil {
 				panic(err)
 			}
@@ -62,12 +62,12 @@ func IdempotentDestroy(ctx *platformtest.Context) {
 	}
 
 	// also test idempotent destroy for cases where the parent dataset does not exist
-	err = zfs.ZFSDestroyIdempotent(fmt.Sprintf("%s/not foo bar@nonexistent snapshot", ctx.RootDataset))
+	err = zfs.ZFSDestroyIdempotent(ctx, fmt.Sprintf("%s/not foo bar@nonexistent snapshot", ctx.RootDataset))
 	if err != nil {
 		panic(err)
 	}
 
-	err = zfs.ZFSDestroyIdempotent(fmt.Sprintf("%s/not foo bar#nonexistent bookmark", ctx.RootDataset))
+	err = zfs.ZFSDestroyIdempotent(ctx, fmt.Sprintf("%s/not foo bar#nonexistent bookmark", ctx.RootDataset))
 	if err != nil {
 		panic(err)
 	}

--- a/platformtest/tests/idempotentHold.go
+++ b/platformtest/tests/idempotentHold.go
@@ -22,7 +22,7 @@ func IdempotentHold(ctx *platformtest.Context) {
 	`)
 
 	fs := fmt.Sprintf("%s/foo bar", ctx.RootDataset)
-	v1 := sendArgVersion(fs, "@1")
+	v1 := sendArgVersion(ctx, fs, "@1")
 
 	tag := "zrepl_platformtest"
 	err := zfs.ZFSHold(ctx, fs, v1, tag)

--- a/platformtest/tests/replicationCursor.go
+++ b/platformtest/tests/replicationCursor.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/zrepl/zrepl/endpoint"
 	"github.com/zrepl/zrepl/platformtest"
 	"github.com/zrepl/zrepl/zfs"
@@ -31,7 +32,7 @@ func ReplicationCursor(ctx *platformtest.Context) {
 	}
 
 	fs := ds.ToString()
-	snap := sendArgVersion(fs, "@1 with space")
+	snap := sendArgVersion(ctx, fs, "@1 with space")
 
 	destroyed, err := endpoint.MoveReplicationCursor(ctx, fs, &snap, jobid)
 	if err != nil {
@@ -39,7 +40,7 @@ func ReplicationCursor(ctx *platformtest.Context) {
 	}
 	assert.Empty(ctx, destroyed)
 
-	snapProps, err := zfs.ZFSGetCreateTXGAndGuid(snap.FullPath(fs))
+	snapProps, err := zfs.ZFSGetCreateTXGAndGuid(ctx, snap.FullPath(fs))
 	if err != nil {
 		panic(err)
 	}
@@ -59,7 +60,7 @@ func ReplicationCursor(ctx *platformtest.Context) {
 	cursor1BookmarkName, err := endpoint.ReplicationCursorBookmarkName(fs, snap.GUID, jobid)
 	require.NoError(ctx, err)
 
-	snap2 := sendArgVersion(fs, "@2 with space")
+	snap2 := sendArgVersion(ctx, fs, "@2 with space")
 	destroyed, err = endpoint.MoveReplicationCursor(ctx, fs, &snap2, jobid)
 	require.NoError(ctx, err)
 	require.Equal(ctx, 1, len(destroyed))

--- a/platformtest/tests/resumeTokenParsing.go
+++ b/platformtest/tests/resumeTokenParsing.go
@@ -16,7 +16,7 @@ type resumeTokenTest struct {
 
 func (rtt *resumeTokenTest) Test(t *platformtest.Context) {
 
-	resumeSendSupported, err := zfs.ResumeSendSupported()
+	resumeSendSupported, err := zfs.ResumeSendSupported(t)
 	if err != nil {
 		t.Errorf("cannot determine whether resume supported: %T %s", err, err)
 		t.FailNow()

--- a/platformtest/tests/sendArgsValidation.go
+++ b/platformtest/tests/sendArgsValidation.go
@@ -23,7 +23,7 @@ func SendArgsValidationEncryptedSendOfUnencryptedDatasetForbidden(ctx *platformt
 	`)
 
 	fs := fmt.Sprintf("%s/send er", ctx.RootDataset)
-	props := mustGetProps(fs + "@a snap")
+	props := mustGetProps(ctx, fs+"@a snap")
 
 	sendArgs := zfs.ZFSSendArgs{
 		FS: fs,
@@ -58,7 +58,7 @@ func SendArgsValidationResumeTokenEncryptionMismatchForbidden(ctx *platformtest.
 	if !supported {
 		ctx.SkipNow()
 	}
-	supported, err = zfs.ResumeSendSupported()
+	supported, err = zfs.ResumeSendSupported(ctx)
 	check(err)
 	if !supported {
 		ctx.SkipNow()
@@ -149,7 +149,7 @@ func SendArgsValidationResumeTokenDifferentFilesystemForbidden(ctx *platformtest
 	if !supported {
 		ctx.SkipNow()
 	}
-	supported, err = zfs.ResumeSendSupported()
+	supported, err = zfs.ResumeSendSupported(ctx)
 	check(err)
 	if !supported {
 		ctx.SkipNow()

--- a/platformtest/tests/undestroyableSnapshotParsing.go
+++ b/platformtest/tests/undestroyableSnapshotParsing.go
@@ -20,7 +20,7 @@ func UndestroyableSnapshotParsing(t *platformtest.Context) {
 		R  zfs hold zrepl_platformtest "${ROOTDS}/foo bar@4 5 6"
 	`)
 
-	err := zfs.ZFSDestroy(fmt.Sprintf("%s/foo bar@1 2 3,4 5 6,7 8 9", t.RootDataset))
+	err := zfs.ZFSDestroy(t, fmt.Sprintf("%s/foo bar@1 2 3,4 5 6,7 8 9", t.RootDataset))
 	if err == nil {
 		panic("expecting destroy error due to hold")
 	}

--- a/zfs/encryption.go
+++ b/zfs/encryption.go
@@ -21,7 +21,7 @@ var encryptionCLISupport struct {
 func EncryptionCLISupported(ctx context.Context) (bool, error) {
 	encryptionCLISupport.once.Do(func() {
 		// "feature discovery"
-		cmd := exec.Command("zfs", "load-key")
+		cmd := exec.CommandContext(ctx, "zfs", "load-key")
 		output, err := cmd.CombinedOutput()
 		if ee, ok := err.(*exec.ExitError); !ok || ok && !ee.Exited() {
 			encryptionCLISupport.err = errors.Wrap(err, "native encryption cli support feature check failed")
@@ -50,7 +50,7 @@ func ZFSGetEncryptionEnabled(ctx context.Context, fs string) (enabled bool, err 
 		return false, err
 	}
 
-	props, err := zfsGet(fs, []string{"encryption"}, sourceAny)
+	props, err := zfsGet(ctx, fs, []string{"encryption"}, sourceAny)
 	if err != nil {
 		return false, errors.Wrap(err, "cannot get `encryption` property")
 	}

--- a/zfs/placeholder.go
+++ b/zfs/placeholder.go
@@ -2,6 +2,7 @@ package zfs
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha512"
 	"encoding/hex"
 	"fmt"
@@ -61,10 +62,10 @@ type FilesystemPlaceholderState struct {
 // is a placeholder. Note that the property source must be `local` for the returned value to be valid.
 //
 // For nonexistent FS, err == nil and state.FSExists == false
-func ZFSGetFilesystemPlaceholderState(p *DatasetPath) (state *FilesystemPlaceholderState, err error) {
+func ZFSGetFilesystemPlaceholderState(ctx context.Context, p *DatasetPath) (state *FilesystemPlaceholderState, err error) {
 	state = &FilesystemPlaceholderState{FS: p.ToString()}
 	state.FS = p.ToString()
-	props, err := zfsGet(p.ToString(), []string{PlaceholderPropertyName}, sourceLocal)
+	props, err := zfsGet(ctx, p.ToString(), []string{PlaceholderPropertyName}, sourceLocal)
 	var _ error = (*DatasetDoesNotExist)(nil) // weak assertion on zfsGet's interface
 	if _, ok := err.(*DatasetDoesNotExist); ok {
 		return state, nil
@@ -77,11 +78,11 @@ func ZFSGetFilesystemPlaceholderState(p *DatasetPath) (state *FilesystemPlacehol
 	return state, nil
 }
 
-func ZFSCreatePlaceholderFilesystem(p *DatasetPath) (err error) {
+func ZFSCreatePlaceholderFilesystem(ctx context.Context, p *DatasetPath) (err error) {
 	if p.Length() == 1 {
 		return fmt.Errorf("cannot create %q: pools cannot be created with zfs create", p.ToString())
 	}
-	cmd := exec.Command(ZFS_BINARY, "create",
+	cmd := exec.CommandContext(ctx, ZFS_BINARY, "create",
 		"-o", fmt.Sprintf("%s=%s", PlaceholderPropertyName, placeholderPropertyOn),
 		"-o", "mountpoint=none",
 		p.ToString())
@@ -103,14 +104,14 @@ func ZFSCreatePlaceholderFilesystem(p *DatasetPath) (err error) {
 	return
 }
 
-func ZFSSetPlaceholder(p *DatasetPath, isPlaceholder bool) error {
+func ZFSSetPlaceholder(ctx context.Context, p *DatasetPath, isPlaceholder bool) error {
 	props := NewZFSProperties()
 	prop := placeholderPropertyOff
 	if isPlaceholder {
 		prop = placeholderPropertyOn
 	}
 	props.Set(PlaceholderPropertyName, prop)
-	return zfsSet(p.ToString(), props)
+	return zfsSet(ctx, p.ToString(), props)
 }
 
 type MigrateHashBasedPlaceholderReport struct {
@@ -119,8 +120,8 @@ type MigrateHashBasedPlaceholderReport struct {
 }
 
 // fs must exist, will panic otherwise
-func ZFSMigrateHashBasedPlaceholderToCurrent(fs *DatasetPath, dryRun bool) (*MigrateHashBasedPlaceholderReport, error) {
-	st, err := ZFSGetFilesystemPlaceholderState(fs)
+func ZFSMigrateHashBasedPlaceholderToCurrent(ctx context.Context, fs *DatasetPath, dryRun bool) (*MigrateHashBasedPlaceholderReport, error) {
+	st, err := ZFSGetFilesystemPlaceholderState(ctx, fs)
 	if err != nil {
 		return nil, fmt.Errorf("error getting placeholder state: %s", err)
 	}
@@ -137,7 +138,7 @@ func ZFSMigrateHashBasedPlaceholderToCurrent(fs *DatasetPath, dryRun bool) (*Mig
 		return &report, nil
 	}
 
-	err = ZFSSetPlaceholder(fs, st.IsPlaceholder)
+	err = ZFSSetPlaceholder(ctx, fs, st.IsPlaceholder)
 	if err != nil {
 		return nil, fmt.Errorf("error re-writing placeholder property: %s", err)
 	}

--- a/zfs/versions_destroy.go
+++ b/zfs/versions_destroy.go
@@ -13,7 +13,7 @@ import (
 	"github.com/zrepl/zrepl/util/envconst"
 )
 
-func ZFSDestroyFilesystemVersion(filesystem *DatasetPath, version *FilesystemVersion) (err error) {
+func ZFSDestroyFilesystemVersion(ctx context.Context, filesystem *DatasetPath, version *FilesystemVersion) (err error) {
 
 	datasetPath := version.ToAbsPath(filesystem)
 
@@ -22,7 +22,7 @@ func ZFSDestroyFilesystemVersion(filesystem *DatasetPath, version *FilesystemVer
 		return fmt.Errorf("sanity check failed: no @ or # character found in %q", datasetPath)
 	}
 
-	return ZFSDestroy(datasetPath)
+	return ZFSDestroy(ctx, datasetPath)
 }
 
 var destroyerSingleton = destroyerImpl{}
@@ -48,8 +48,8 @@ func setDestroySnapOpErr(b []*DestroySnapOp, err error) {
 }
 
 type destroyer interface {
-	Destroy(args []string) error
-	DestroySnapshotsCommaSyntaxSupported() (bool, error)
+	Destroy(ctx context.Context, args []string) error
+	DestroySnapshotsCommaSyntaxSupported(context.Context) (bool, error)
 }
 
 func doDestroy(ctx context.Context, reqs []*DestroySnapOp, e destroyer) {
@@ -69,7 +69,7 @@ func doDestroy(ctx context.Context, reqs []*DestroySnapOp, e destroyer) {
 	}
 	reqs = validated
 
-	commaSupported, err := e.DestroySnapshotsCommaSyntaxSupported()
+	commaSupported, err := e.DestroySnapshotsCommaSyntaxSupported(ctx)
 	if err != nil {
 		debug("destroy: comma syntax support detection failed: %s", err)
 		setDestroySnapOpErr(reqs, err)
@@ -85,7 +85,7 @@ func doDestroy(ctx context.Context, reqs []*DestroySnapOp, e destroyer) {
 
 func doDestroySeq(ctx context.Context, reqs []*DestroySnapOp, e destroyer) {
 	for _, r := range reqs {
-		*r.ErrOut = e.Destroy([]string{fmt.Sprintf("%s@%s", r.Filesystem, r.Name)})
+		*r.ErrOut = e.Destroy(ctx, []string{fmt.Sprintf("%s@%s", r.Filesystem, r.Name)})
 	}
 }
 
@@ -139,7 +139,7 @@ func tryBatch(ctx context.Context, batch []*DestroySnapOp, d destroyer) error {
 		}
 	}
 	batchArg := fmt.Sprintf("%s@%s", batchFS, strings.Join(batchNames, ","))
-	return d.Destroy([]string{batchArg})
+	return d.Destroy(ctx, []string{batchArg})
 }
 
 // fsbatch must be on same filesystem
@@ -203,7 +203,7 @@ func doDestroyBatchedRec(ctx context.Context, fsbatch []*DestroySnapOp, d destro
 
 type destroyerImpl struct{}
 
-func (d destroyerImpl) Destroy(args []string) error {
+func (d destroyerImpl) Destroy(ctx context.Context, args []string) error {
 	if len(args) != 1 {
 		// we have no use case for this at the moment, so let's crash (safer than destroying something unexpectedly)
 		panic(fmt.Sprintf("unexpected number of arguments: %v", args))
@@ -212,7 +212,7 @@ func (d destroyerImpl) Destroy(args []string) error {
 	if !strings.ContainsAny(args[0], "@") {
 		panic(fmt.Sprintf("sanity check: expecting '@' in call to Destroy, got %q", args[0]))
 	}
-	return ZFSDestroy(args[0])
+	return ZFSDestroy(ctx, args[0])
 }
 
 var batchDestroyFeatureCheck struct {
@@ -221,10 +221,10 @@ var batchDestroyFeatureCheck struct {
 	err    error
 }
 
-func (d destroyerImpl) DestroySnapshotsCommaSyntaxSupported() (bool, error) {
+func (d destroyerImpl) DestroySnapshotsCommaSyntaxSupported(ctx context.Context) (bool, error) {
 	batchDestroyFeatureCheck.once.Do(func() {
 		// "feature discovery"
-		cmd := exec.Command(ZFS_BINARY, "destroy")
+		cmd := exec.CommandContext(ctx, ZFS_BINARY, "destroy")
 		output, err := cmd.CombinedOutput()
 		if _, ok := err.(*exec.ExitError); !ok {
 			debug("destroy feature check failed: %T %s", err, err)

--- a/zfs/versions_destroy_test.go
+++ b/zfs/versions_destroy_test.go
@@ -25,11 +25,11 @@ type mockBatchDestroy struct {
 	e2biglen         int
 }
 
-func (m *mockBatchDestroy) DestroySnapshotsCommaSyntaxSupported() (bool, error) {
+func (m *mockBatchDestroy) DestroySnapshotsCommaSyntaxSupported(_ context.Context) (bool, error) {
 	return !m.commaUnsupported, nil
 }
 
-func (m *mockBatchDestroy) Destroy(args []string) error {
+func (m *mockBatchDestroy) Destroy(ctx context.Context, args []string) error {
 	defer m.mtx.Lock().Unlock()
 	if len(args) != 1 {
 		panic("unexpected use of Destroy")

--- a/zfs/zfs_test.go
+++ b/zfs/zfs_test.go
@@ -1,6 +1,7 @@
 package zfs
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,9 +12,11 @@ func TestZFSListHandlesProducesZFSErrorOnNonZeroExit(t *testing.T) {
 
 	var err error
 
+	ctx := context.Background()
+
 	ZFS_BINARY = "./test_helpers/zfs_failer.sh"
 
-	_, err = ZFSList([]string{"fictionalprop"}, "nonexistent/dataset")
+	_, err = ZFSList(ctx, []string{"fictionalprop"}, "nonexistent/dataset")
 
 	assert.Error(t, err)
 	zfsError, ok := err.(*ZFSError)


### PR DESCRIPTION
Laying the groundwork to logging all /bin/zfs calls.