### PR TITLE
pIn dockerfile base image to v1.14.7

### DIFF
--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest
+FROM golang:1.14.7
 
 RUN apt-get update && apt-get install -y \
     python3-pip \
@@ -27,4 +27,3 @@ ADD build/ /tmp/build
 RUN /tmp/lazy.sh godep
 
 RUN chmod -R 0777 /go
-


### PR DESCRIPTION
relates to https://github.com/hadolint/hadolint/wiki/DL3007

> Using latest is prone to errors if the image will ever update. Pin the version explicitly to a release tag.