### PR TITLE
Fixing link to template.sh sample hook file

### DIFF
--- a/docs/configuration/snapshotting.rst
+++ b/docs/configuration/snapshotting.rst
@@ -131,7 +131,7 @@ The following environment variables are set:
 * ``ZREPL_SNAPNAME``: the zrepl-generated snapshot name (e.g. ``zrepl_20380119_031407_000``)
 * ``ZREPL_DRYRUN``: set to ``"true"`` if a dry run is in progress so scripts can print, but not run, their commands
 
-An empty template hook can be found in :sampleconf:`hooks/template.sh`.
+An empty template hook can be found in :sampleconf:`/hooks/template.sh`.
 
 .. _job-hook-type-postgres-checkpoint:
 


### PR DESCRIPTION
The link to the sample hook file currently goes to sampleshooks/template.sh instead of samples/hooks/template.sh