### PR TITLE
rpc: fix read mutex unlock in dataconn stream

### DIFF
--- a/rpc/dataconn/stream/stream_conn.go
+++ b/rpc/dataconn/stream/stream_conn.go
@@ -144,6 +144,7 @@ func (c *Conn) ReadStream(frameType uint32, closeConnOnClose bool) (_ *StreamRea
 
 	c.readMtx.Lock()
 	if !c.readClean {
+		c.readMtx.Unlock()
 		return nil, errWriteStreamToErrorUnknownState
 	}
 


### PR DESCRIPTION
I took a closer look at the goroutine traces in #411 to narrow down the scope and found one suspicious mutex that was not being unlocked in the event of an error (unclean read).

Currently putting this PR through the test to see if it fixes the issues I've been having. May potentially fix the freebsd side as well?