### PR TITLE
daemon: guard trace id generation with mutex

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"os"
 	"os/signal"
 	"strings"
@@ -37,6 +38,12 @@ func Run(ctx context.Context, conf *config.Config) error {
 		<-sigChan
 		cancel()
 	}()
+
+	// The math/rand package is used presently for generating trace IDs, we
+	// seed it with the current time and pid so that the IDs are mostly
+	// unique.
+	rand.Seed(time.Now().UnixNano())
+	rand.Seed(int64(os.Getpid()))
 
 	outlets, err := logging.OutletsFromConfig(*conf.Global.Logging)
 	if err != nil {

--- a/daemon/logging/trace/trace_genID.go
+++ b/daemon/logging/trace/trace_genID.go
@@ -3,19 +3,10 @@ package trace
 import (
 	"encoding/base64"
 	"math/rand"
-	"os"
 	"strings"
-	"time"
 
 	"github.com/zrepl/zrepl/util/envconst"
 )
-
-var genIdPRNG = rand.New(rand.NewSource(1))
-
-func init() {
-	genIdPRNG.Seed(time.Now().UnixNano())
-	genIdPRNG.Seed(int64(os.Getpid()))
-}
 
 var genIdNumBytes = envconst.Int("ZREPL_TRACE_ID_NUM_BYTES", 3)
 
@@ -30,7 +21,7 @@ func genID() string {
 	enc := base64.NewEncoder(base64.RawStdEncoding, &out)
 	buf := make([]byte, genIdNumBytes)
 	for i := 0; i < len(buf); {
-		n, err := genIdPRNG.Read(buf[i:])
+		n, err := rand.Read(buf[i:])
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
This is probably low-hanging fruit but was caught by the race detector and was an easy fix.

Let me know if the go lint fix of `Id` -> `ID` is unwanted and I'll revert.