### PR TITLE
daemon: fix data race in snapjob pruner report

### DIFF
--- a/daemon/job/snapjob.go
+++ b/daemon/job/snapjob.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"sync"
 
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -29,7 +30,8 @@ type SnapJob struct {
 
 	promPruneSecs *prometheus.HistogramVec // labels: prune_side
 
-	pruner *pruner.Pruner
+	prunerMu sync.Mutex
+	pruner   *pruner.Pruner
 }
 
 func (j *SnapJob) Name() string { return j.name.String() }
@@ -77,9 +79,11 @@ type SnapJobStatus struct {
 func (j *SnapJob) Status() *Status {
 	s := &SnapJobStatus{}
 	t := j.Type()
+	j.prunerMu.Lock()
 	if j.pruner != nil {
 		s.Pruning = j.pruner.Report()
 	}
+	j.prunerMu.Unlock()
 	s.Snapshotting = j.snapper.Report()
 	return &Status{Type: t, JobSpecific: s}
 }
@@ -177,7 +181,9 @@ func (j *SnapJob) doPrune(ctx context.Context) {
 		// FIXME encryption setting is irrelevant for SnapJob because the endpoint is only used as pruner.Target
 		Encrypt: &zfs.NilBool{B: true},
 	})
+	j.prunerMu.Lock()
 	j.pruner = j.prunerFactory.BuildLocalPruner(ctx, sender, alwaysUpToDateReplicationCursorHistory{sender})
+	j.prunerMu.Unlock()
 	log.Info("start pruning")
 	j.pruner.Prune()
 	log.Info("finished pruning")


### PR DESCRIPTION
I saw another data race as I was running zrepl built with `-race`.

The first one looked easy enough to fix (SnapJob.Status/doPrune), was simply a concurrent read and write to `(*SnapJob).pruner`. The second one I'm not so sure about, if this PR doesn't fix it, I'll move it to a separate issue (I'm in the process of testing this PR now).

<details>
<summary>WARNING: DATA RACE: SnapJob.Status/doPrune</summary>

```
==================
WARNING: DATA RACE
Read at 0x00c0001c96f8 by goroutine 48:
  github.com/zrepl/zrepl/daemon/job.(*SnapJob).Status()
      /root/go/src/github.com/zrepl/zrepl/daemon/job/snapjob.go:80 +0x94
  github.com/zrepl/zrepl/daemon.(*jobs).status.func1()
      /root/go/src/github.com/zrepl/zrepl/daemon/daemon.go:174 +0x82

Previous write at 0x00c0001c96f8 by goroutine 37:
  github.com/zrepl/zrepl/daemon/job.(*SnapJob).doPrune()
      /root/go/src/github.com/zrepl/zrepl/daemon/job/snapjob.go:180 +0x2ee
  github.com/zrepl/zrepl/daemon/job.(*SnapJob).Run()
      /root/go/src/github.com/zrepl/zrepl/daemon/job/snapjob.go:122 +0x3e6
  github.com/zrepl/zrepl/daemon.(*jobs).start.func1()
      /root/go/src/github.com/zrepl/zrepl/daemon/daemon.go:248 +0x19c

Goroutine 48 (running) created at:
  github.com/zrepl/zrepl/daemon.(*jobs).status()
      /root/go/src/github.com/zrepl/zrepl/daemon/daemon.go:172 +0x2c4
  github.com/zrepl/zrepl/daemon.(*controlJob).Run.func3()
      /root/go/src/github.com/zrepl/zrepl/daemon/control.go:121 +0x64
  github.com/zrepl/zrepl/daemon.jsonResponder.ServeHTTP()
      /root/go/src/github.com/zrepl/zrepl/daemon/control.go:202 +0x9b
  github.com/zrepl/zrepl/daemon.(*jsonResponder).ServeHTTP()
      <autogenerated>:1 +0x9d
  net/http.(*ServeMux).ServeHTTP()
      /usr/local/go/src/net/http/server.go:2417 +0xaf
  net/http.serverHandler.ServeHTTP()
      /usr/local/go/src/net/http/server.go:2843 +0xca
  net/http.(*conn).serve()
      /usr/local/go/src/net/http/server.go:1925 +0x84c

Goroutine 37 (running) created at:
  github.com/zrepl/zrepl/daemon.(*jobs).start()
      /root/go/src/github.com/zrepl/zrepl/daemon/daemon.go:244 +0x530
  github.com/zrepl/zrepl/daemon.Run()
      /root/go/src/github.com/zrepl/zrepl/daemon/daemon.go:108 +0xe75
  github.com/zrepl/zrepl/daemon.glob..func1()
      /root/go/src/github.com/zrepl/zrepl/daemon/main.go:16 +0x84
  github.com/zrepl/zrepl/cli.(*Subcommand).run()
      /root/go/src/github.com/zrepl/zrepl/cli/cli.go:105 +0x134
  github.com/zrepl/zrepl/cli.(*Subcommand).run-fm()
      /root/go/src/github.com/zrepl/zrepl/cli/cli.go:100 +0x69
  github.com/spf13/cobra.(*Command).execute()
      /root/go/pkg/mod/github.com/spf13/cobra@v0.0.2/command.go:760 +0x90c
  github.com/spf13/cobra.(*Command).ExecuteC()
      /root/go/pkg/mod/github.com/spf13/cobra@v0.0.2/command.go:846 +0x42f
  github.com/spf13/cobra.(*Command).Execute()
      /root/go/pkg/mod/github.com/spf13/cobra@v0.0.2/command.go:794 +0x4a
  github.com/zrepl/zrepl/cli.Run()
      /root/go/src/github.com/zrepl/zrepl/cli/cli.go:152 +0x2b
  main.main()
      /root/go/src/github.com/zrepl/zrepl/main.go:24 +0x2f
  runtime.main()
      /usr/local/go/src/runtime/proc.go:204 +0x208
  github.com/zrepl/zrepl/cli.addSubcommandToCobraCmd()
      /root/go/src/github.com/zrepl/zrepl/cli/cli.go:142 +0x20e
  github.com/zrepl/zrepl/cli.addSubcommandToCobraCmd()
      /root/go/src/github.com/zrepl/zrepl/cli/cli.go:142 +0x20e
  github.com/zrepl/zrepl/cli.AddSubcommand()
      /root/go/src/github.com/zrepl/zrepl/cli/cli.go:129 +0x2fe
  main.init.0()
      /root/go/src/github.com/zrepl/zrepl/main.go:20 +0x2b1
==================
```

</details>

<details>
<summary>WARNING: DATA RACE: Pruner.Report / SnapJob.Status</summary>

```
==================
WARNING: DATA RACE
Read at 0x00c00089e260 by goroutine 48:
  github.com/zrepl/zrepl/daemon/pruner.(*Pruner).Report()
      /root/go/src/github.com/zrepl/zrepl/daemon/pruner/pruner.go:237 +0xe4
  github.com/zrepl/zrepl/daemon/job.(*SnapJob).Status()
      /root/go/src/github.com/zrepl/zrepl/daemon/job/snapjob.go:81 +0x20e
  github.com/zrepl/zrepl/daemon.(*jobs).status.func1()
      /root/go/src/github.com/zrepl/zrepl/daemon/daemon.go:174 +0x82

Previous write at 0x00c00089e260 by goroutine 37:
  github.com/zrepl/zrepl/daemon/pruner.(*LocalPrunerFactory).BuildLocalPruner()
      /root/go/src/github.com/zrepl/zrepl/daemon/pruner/pruner.go:168 +0x187
  github.com/zrepl/zrepl/daemon/job.(*SnapJob).doPrune()
      /root/go/src/github.com/zrepl/zrepl/daemon/job/snapjob.go:180 +0x2c4
  github.com/zrepl/zrepl/daemon/job.(*SnapJob).Run()
      /root/go/src/github.com/zrepl/zrepl/daemon/job/snapjob.go:122 +0x3e6
  github.com/zrepl/zrepl/daemon.(*jobs).start.func1()
      /root/go/src/github.com/zrepl/zrepl/daemon/daemon.go:248 +0x19c

Goroutine 48 (running) created at:
  github.com/zrepl/zrepl/daemon.(*jobs).status()
      /root/go/src/github.com/zrepl/zrepl/daemon/daemon.go:172 +0x2c4
  github.com/zrepl/zrepl/daemon.(*controlJob).Run.func3()
      /root/go/src/github.com/zrepl/zrepl/daemon/control.go:121 +0x64
  github.com/zrepl/zrepl/daemon.jsonResponder.ServeHTTP()
      /root/go/src/github.com/zrepl/zrepl/daemon/control.go:202 +0x9b
  github.com/zrepl/zrepl/daemon.(*jsonResponder).ServeHTTP()
      <autogenerated>:1 +0x9d
  net/http.(*ServeMux).ServeHTTP()
      /usr/local/go/src/net/http/server.go:2417 +0xaf
  net/http.serverHandler.ServeHTTP()
      /usr/local/go/src/net/http/server.go:2843 +0xca
  net/http.(*conn).serve()
      /usr/local/go/src/net/http/server.go:1925 +0x84c

Goroutine 37 (running) created at:
  github.com/zrepl/zrepl/daemon.(*jobs).start()
      /root/go/src/github.com/zrepl/zrepl/daemon/daemon.go:244 +0x530
  github.com/zrepl/zrepl/daemon.Run()
      /root/go/src/github.com/zrepl/zrepl/daemon/daemon.go:108 +0xe75
  github.com/zrepl/zrepl/daemon.glob..func1()
      /root/go/src/github.com/zrepl/zrepl/daemon/main.go:16 +0x84
  github.com/zrepl/zrepl/cli.(*Subcommand).run()
      /root/go/src/github.com/zrepl/zrepl/cli/cli.go:105 +0x134
  github.com/zrepl/zrepl/cli.(*Subcommand).run-fm()
      /root/go/src/github.com/zrepl/zrepl/cli/cli.go:100 +0x69
  github.com/spf13/cobra.(*Command).execute()
      /root/go/pkg/mod/github.com/spf13/cobra@v0.0.2/command.go:760 +0x90c
  github.com/spf13/cobra.(*Command).ExecuteC()
      /root/go/pkg/mod/github.com/spf13/cobra@v0.0.2/command.go:846 +0x42f
  github.com/spf13/cobra.(*Command).Execute()
      /root/go/pkg/mod/github.com/spf13/cobra@v0.0.2/command.go:794 +0x4a
  github.com/zrepl/zrepl/cli.Run()
      /root/go/src/github.com/zrepl/zrepl/cli/cli.go:152 +0x2b
  main.main()
      /root/go/src/github.com/zrepl/zrepl/main.go:24 +0x2f
  runtime.main()
      /usr/local/go/src/runtime/proc.go:204 +0x208
  github.com/zrepl/zrepl/cli.addSubcommandToCobraCmd()
      /root/go/src/github.com/zrepl/zrepl/cli/cli.go:142 +0x20e
  github.com/zrepl/zrepl/cli.addSubcommandToCobraCmd()
      /root/go/src/github.com/zrepl/zrepl/cli/cli.go:142 +0x20e
  github.com/zrepl/zrepl/cli.AddSubcommand()
      /root/go/src/github.com/zrepl/zrepl/cli/cli.go:129 +0x2fe
  main.init.0()
      /root/go/src/github.com/zrepl/zrepl/main.go:20 +0x2b1
==================
```

</details>