### PR TITLE
Systemd: Add zrepl-job@.{timer,service} units and zrepl_timers.target

### DIFF
--- a/dist/systemd/zrepl-job.service
+++ b/dist/systemd/zrepl-job.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=zrepl job %i wakeup
+After=zrepl.service
+
+# Don't do this to yourself
+# unless you want job units to keep starting zrepl while you're trying to keep the daemon stopped for a moment...
+# Requires=zrepl.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/zrepl signal wakeup %i
+
+[Install]
+WantedBy=multi-user.target

--- a/dist/systemd/zrepl-job.service
+++ b/dist/systemd/zrepl-job.service
@@ -8,7 +8,7 @@ After=zrepl.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/local/bin/zrepl signal wakeup %i
+ExecStart=/usr/local/bin/zrepl signal wakeup %I
 
 [Install]
 WantedBy=multi-user.target

--- a/dist/systemd/zrepl-job.timer
+++ b/dist/systemd/zrepl-job.timer
@@ -1,0 +1,20 @@
+[Unit]
+Description=zrepl - timer for job %i
+After=zrepl.service
+
+[Timer]
+Unit=zrepl-job@%i.service
+
+# Set an irrelevant default trigger to make systemd happy
+OnStartupSec=100y
+
+# Extend your job's timer unit to bring your own intervals!
+# See the systemd.timer(5) and systemd.time(7) man pages
+# $ systemctl edit zrepl-job@example_job.timer
+# [Timer]
+# #OnUnitActiveSec=
+# # or
+# #OnCalendar=
+
+[Install]
+WantedBy=zrepl_timers.target

--- a/dist/systemd/zrepl_timers.target
+++ b/dist/systemd/zrepl_timers.target
@@ -1,0 +1,3 @@
+[Unit]
+Description=Zrepl Timers
+DefaultDependencies=no


### PR DESCRIPTION
Allows a user to trigger a job through systemd by starting zrepl-job@`$JOBNAME|systemd-escape`.service,
e.g. by simply enabling zrepl-job@`$JOBNAME|systemd-escape`.timer and setting the desired trigger condition,
e.g. via systemctl edit zrepl-job@`$JOBNAME|systemd-escape`.timer.

Signed-off-by: InsanePrawn <insane.prawny@gmail.com>

## TODO

- [ ] Documentation
- [ ] Finalize unit names (zrepl_timers.target? zrepl-timers.target?)
- [ ] Wait for 0.4 and new signalling code?
- [ ] Decide on what type of subshell-ish syntax to use for the pseudocode in the commit message 🙃