### PR TITLE
[WIP] Add "wait" command for blocking until a job is finished

### DIFF
--- a/client/wait.go
+++ b/client/wait.go
@@ -1,0 +1,276 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/gdamore/tcell/termbox"
+	"github.com/pkg/errors"
+
+	"github.com/zrepl/zrepl/cli"
+	"github.com/zrepl/zrepl/config"
+	"github.com/zrepl/zrepl/daemon"
+	"github.com/zrepl/zrepl/daemon/job"
+	"github.com/zrepl/zrepl/daemon/pruner"
+	"github.com/zrepl/zrepl/daemon/snapper"
+	"github.com/zrepl/zrepl/replication/report"
+)
+
+type wui struct {
+	//lock      sync.Mutex //For report and error
+	report map[string]*job.Status
+	cancel bool
+
+	jobName string
+}
+
+var WaitCmd = &cli.Subcommand{
+	Use:   "wait JOB",
+	Short: "block and wait until the specified job is done or has failed",
+	Run: func(ctx context.Context, subcommand *cli.Subcommand, args []string) error {
+		return runWaitCmd(subcommand.Config(), args)
+	},
+}
+
+// adapted from status.go
+func runWaitCmd(config *config.Config, args []string) error {
+	if len(args) != 1 {
+		return errors.Errorf("Expected 1 argument: JOB")
+	}
+
+	// TODO: poll status until done or error
+	httpc, err := controlHttpClient(config.Global.Control.SockPath)
+	if err != nil {
+		return err
+	}
+
+	t := wui{
+		report:  nil,
+		cancel:  false,
+		jobName: args[0],
+	}
+
+	// wait for cancellation by user
+	err = termbox.Init()
+	if err != nil {
+		return err
+	}
+	defer termbox.Close()
+	go func() {
+	loop:
+		for {
+			switch ev := termbox.PollEvent(); ev.Type {
+			case termbox.EventKey:
+				switch ev.Key {
+				case termbox.KeyCtrlC:
+					// TODO: needs locking?
+					t.cancel = true
+					break loop
+				}
+			}
+		}
+	}()
+
+	updateAndEvaluate := func() (bool, error) {
+		var m daemon.Status
+
+		err := jsonRequestResponse(httpc, daemon.ControlJobEndpointStatus,
+			struct{}{},
+			&m,
+		)
+		if err != nil {
+			return true, fmt.Errorf("can't get status from daemon: %w", err)
+		}
+
+		t.report = m.Jobs
+
+		return t.evaluate()
+	}
+	updateAndEvaluate()
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+ticker:
+	for range ticker.C {
+		if t.cancel {
+			break ticker
+		}
+
+		done, err := updateAndEvaluate()
+		if err != nil {
+			return err
+		}
+		if done {
+			break ticker
+		}
+	}
+
+	return nil
+}
+
+func (t *wui) evaluate() (bool, error) {
+	v, ok := t.report[t.jobName]
+	if !ok {
+		return true, fmt.Errorf("job not in status: %v", t.jobName)
+	}
+
+	if v.Type == job.TypePush || v.Type == job.TypePull {
+		activeStatus, ok := v.JobSpecific.(*job.ActiveSideStatus)
+		if !ok || activeStatus == nil {
+			// TODO: ignore?
+			return true, nil //error.New("ActiveSideStatus is null")
+		}
+
+		//t.renderReplicationReport(activeStatus.Replication, t.getReplicationProgressHistory(k))
+		replicationDone, err := evaluateReplicationReport(activeStatus.Replication)
+		if err != nil {
+			return true, err
+		}
+
+		senderPruningDone, err := evaluatePruningReport(activeStatus.PruningSender)
+		if err != nil {
+			return true, fmt.Errorf("sender %w", err)
+		}
+		receiverPruningDone, err := evaluatePruningReport(activeStatus.PruningReceiver)
+		if err != nil {
+			return true, fmt.Errorf("receiver %w", err)
+		}
+
+		done := replicationDone && senderPruningDone && receiverPruningDone
+
+		if v.Type == job.TypePush {
+			snapperDone, err := evaluateSnapperReport(activeStatus.Snapshotting)
+			if err != nil {
+				return true, err
+			}
+
+			done = done && snapperDone
+		}
+
+		return done, nil
+	} else if v.Type == job.TypeSnap {
+		snapStatus, ok := v.JobSpecific.(*job.SnapJobStatus)
+		if !ok || snapStatus == nil {
+			// TODO: ignore?
+			return true, nil //error.Error("SnapJobStatus is null")
+		}
+
+		pruningDone, err := evaluatePruningReport(snapStatus.Pruning)
+		if err != nil {
+			return true, err
+		}
+
+		snapperDone, err := evaluateSnapperReport(snapStatus.Snapshotting)
+		if err != nil {
+			return true, err
+		}
+
+		return pruningDone && snapperDone, nil
+	} else if v.Type == job.TypeSource || v.Type == job.TypeSink {
+		snapStatus, ok := v.JobSpecific.(*job.PassiveStatus)
+		if !ok || snapStatus == nil {
+			// TODO: ignore?
+			return true, nil //error.Error("SnapJobStatus is null")
+		}
+
+		snapperDone, err := evaluateSnapperReport(snapStatus.Snapper)
+		if err != nil {
+			return true, err
+		}
+
+		return snapperDone, nil
+
+	} else {
+		return true, fmt.Errorf("unknown job type")
+	}
+}
+
+func evaluatePruningReport(r *pruner.Report) (bool, error) {
+	if r == nil {
+		// ignore
+		return true, nil
+	}
+
+	if r.Error != "" {
+		return true, fmt.Errorf("pruning error: %v", r.Error)
+	}
+
+	prunerState, err := pruner.StateString(r.State)
+	if err != nil {
+		return true, fmt.Errorf("parsing pruning state %v: %w", r.State, err)
+	}
+
+	switch prunerState {
+	case pruner.PlanErr:
+		fallthrough
+	case pruner.ExecErr:
+		return true, fmt.Errorf("pruning failed with state: %v", prunerState)
+	case pruner.Done:
+		return true, nil
+	default:
+		// no errros, but still not finished
+		return false, nil
+	}
+}
+
+func evaluateReplicationReport(rep *report.Report) (bool, error) {
+	if rep == nil {
+		// ignore
+		return true, nil
+	}
+
+	if rep.WaitReconnectError != nil {
+		return true, fmt.Errorf("Connectivity: %v", rep.WaitReconnectError)
+	}
+	if !rep.WaitReconnectSince.IsZero() {
+		delta := time.Until(rep.WaitReconnectUntil).Round(time.Second)
+		if rep.WaitReconnectUntil.IsZero() || delta > 0 {
+			// ignore, will reconnect
+		} else {
+			return true, fmt.Errorf("Connectivity: reconnects reached hard-fail timeout @ %s", rep.WaitReconnectUntil)
+		}
+	}
+
+	if len(rep.Attempts) == 0 {
+		return false, nil
+	}
+
+	latest := rep.Attempts[len(rep.Attempts)-1]
+	switch latest.State {
+	case report.AttemptPlanningError:
+		fallthrough
+	case report.AttemptFanOutError:
+		return true, fmt.Errorf("last replication attept failed with state %v", latest.State)
+	case report.AttemptDone:
+		return true, nil
+	default:
+		// no errros, but still not finished
+		return false, nil
+	}
+}
+
+func evaluateSnapperReport(r *snapper.Report) (bool, error) {
+	if r == nil {
+		// ignore
+		return true, nil
+	}
+
+	if r.Error != "" {
+		return true, fmt.Errorf("snapshotting error: %v", r.Error)
+	}
+
+	switch r.State {
+	case snapper.SyncUpErrWait:
+		fallthrough
+	case snapper.ErrorWait:
+		// some filesystems had an error
+		return true, fmt.Errorf("snapshotting failed with state: %v", r.State)
+	case snapper.Waiting:
+		// TODO: also snapper.Stopped
+		return true, nil
+	default:
+		// no errros, but still not finished
+		return false, nil
+	}
+}

--- a/client/wait_job.go
+++ b/client/wait_job.go
@@ -18,19 +18,17 @@ import (
 
 var WaitJobCmd = &cli.Subcommand{
 	Use:   "wait-job JOB",
-	Short: "block and wait until the specified job is done or has failed",
+	Short: "block and wait until the specified job finishes successfully or fails",
 	Run: func(ctx context.Context, subcommand *cli.Subcommand, args []string) error {
 		return runWaitJobCmd(subcommand.Config(), args)
 	},
 }
 
-// adapted from status.go
 func runWaitJobCmd(config *config.Config, args []string) error {
 	if len(args) != 1 {
 		return errors.Errorf("Expected 1 argument: JOB")
 	}
 
-	// TODO: poll status until done or error
 	c, err := client.New("unix", config.Global.Control.SockPath)
 	if err != nil {
 		return errors.Wrapf(err, "connect to daemon socket at %q", config.Global.Control.SockPath)
@@ -74,7 +72,6 @@ ticker:
 }
 
 func evaluateJobStatus(j *job.Status) (bool, error) {
-
 	if j.Type == job.TypePush || j.Type == job.TypePull {
 		activeStatus, ok := j.JobSpecific.(*job.ActiveSideStatus)
 		if !ok || activeStatus == nil {
@@ -82,7 +79,6 @@ func evaluateJobStatus(j *job.Status) (bool, error) {
 			return true, nil //error.New("ActiveSideStatus is null")
 		}
 
-		//t.renderReplicationReport(activeStatus.Replication, t.getReplicationProgressHistory(k))
 		replicationDone, err := evaluateReplicationStatus(activeStatus.Replication)
 		if err != nil {
 			return true, err

--- a/daemon/pruner/pruner.go
+++ b/daemon/pruner/pruner.go
@@ -191,6 +191,26 @@ const (
 	Done
 )
 
+func (s State) IsError() bool {
+	switch s {
+	case PlanErr:
+		fallthrough
+	case ExecErr:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s State) IsTerminal() bool {
+	switch s {
+	case Done:
+		return true
+	default:
+		return false
+	}
+}
+
 type updater func(func(*Pruner))
 
 func (p *Pruner) Prune() {

--- a/daemon/snapper/snapper.go
+++ b/daemon/snapper/snapper.go
@@ -101,6 +101,27 @@ func (s State) sf() state {
 	return m[s]
 }
 
+func (s State) IsError() bool {
+	switch s {
+	case SyncUpErrWait:
+		fallthrough
+	case ErrorWait:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s State) IsTerminal() bool {
+	switch s {
+	case Waiting:
+		// FIXME: also Stopped?
+		return true
+	default:
+		return false
+	}
+}
+
 type updater func(u func(*Snapper)) State
 type state func(a args, u updater) state
 

--- a/main.go
+++ b/main.go
@@ -18,7 +18,7 @@ func init() {
 	cli.AddSubcommand(client.PprofCmd)
 	cli.AddSubcommand(client.TestCmd)
 	cli.AddSubcommand(client.MigrateCmd)
-	cli.AddSubcommand(client.WaitCmd)
+	cli.AddSubcommand(client.WaitJobCmd)
 	cli.AddSubcommand(client.ZFSAbstractionsCmd)
 }
 

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ func init() {
 	cli.AddSubcommand(client.PprofCmd)
 	cli.AddSubcommand(client.TestCmd)
 	cli.AddSubcommand(client.MigrateCmd)
+	cli.AddSubcommand(client.WaitCmd)
 	cli.AddSubcommand(client.ZFSAbstractionsCmd)
 }
 

--- a/replication/report/replication_report.go
+++ b/replication/report/replication_report.go
@@ -52,6 +52,26 @@ const (
 	AttemptDone          AttemptState = "done"
 )
 
+func (s AttemptState) IsError() bool {
+	switch s {
+	case AttemptPlanningError:
+		fallthrough
+	case AttemptFanOutError:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s AttemptState) IsTerminal() bool {
+	switch s {
+	case AttemptDone:
+		return true
+	default:
+		return false
+	}
+}
+
 type FilesystemState string
 
 const (


### PR DESCRIPTION
This is a rough first implementation for  #427.

Design decisions:
- calling the subcommand "wait"
- allow waiting only for one job

Non-descisions (i.e. there was no thought behind it):
- code structure and variable names mimic client/status
- sleep time between checks (currently 500msec)

Caveats:
- I'm writing Go for the first time
- I have relatively little experience with zrepl
- I only have a simple setup
- no (integration) tests

Todos:
- cover more corner cases ...
  -  .. through feedback 
  -  ... with tests
- better naming and code structure (any suggestions guidelines?)
- should there be meaningful error codes?
- should there be status/debug output?

Fixes  #427