### PR TITLE
client/status: allow raw mode without a tty

### DIFF
--- a/client/status/status.go
+++ b/client/status/status.go
@@ -71,12 +71,16 @@ func runStatusV2Command(ctx context.Context, config *config.Config, args []strin
 
 	mode := statusv2Flags.Mode.Value().(statusv2Mode)
 
-	if !isatty.IsTerminal(os.Stdout.Fd()) && mode != StatusV2ModeDump {
-		usemode, err := statusv2Flags.Mode.InputForChoice(StatusV2ModeDump)
+	if !isatty.IsTerminal(os.Stdout.Fd()) && mode != StatusV2ModeDump && mode != StatusV2ModeRaw {
+		dumpmode, err := statusv2Flags.Mode.InputForChoice(StatusV2ModeDump)
 		if err != nil {
 			panic(err)
 		}
-		return errors.Errorf("error: stdout is not a tty, please use --mode %s", usemode)
+		rawmode, err := statusv2Flags.Mode.InputForChoice(StatusV2ModeRaw)
+		if err != nil {
+			panic(err)
+		}
+		return errors.Errorf("error: stdout is not a tty, please use --mode %s or --mode %s", dumpmode, rawmode)
 	}
 
 	switch mode {


### PR DESCRIPTION
A fairly common pattern when presented with JSON is to pipe it to `jq`.

This also allows one to `zrepl status --mode raw > log` and operate on
the JSON there.

---

Prior to this change, attempting to pipe to `jq` would greet me with:

```
$ doas zrepl status --mode raw | jq
error: stdout is not a tty, please use --mode dump
```

Now:

```
$ doas zrepl status --mode raw | jq | head
{
  "Jobs": {
    "_control": {
      "internal": null,
      "type": "internal"
    },
    "bpool_sink": {
      "sink": {
        "Snapper": null
      },
```