### PR TITLE
systemd: enable restarting zrepl service

### DIFF
--- a/dist/systemd/zrepl.service
+++ b/dist/systemd/zrepl.service
@@ -4,6 +4,7 @@ Documentation=https://zrepl.github.io
 
 [Service]
 Type=simple
+Restart=always
 ExecStartPre=/usr/local/bin/zrepl --config /etc/zrepl/zrepl.yml configcheck
 ExecStart=/usr/local/bin/zrepl --config /etc/zrepl/zrepl.yml daemon
 RuntimeDirectory=zrepl zrepl/stdinserver


### PR DESCRIPTION
This is useful if the zrepl daemon has an error for any reason and exits.