### PR TITLE
job snapshots prefix for replication filtering

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -123,14 +123,16 @@ type PropertyRecvOptions struct {
 }
 
 type PushJob struct {
-	ActiveJob    `yaml:",inline"`
-	Snapshotting SnapshottingEnum  `yaml:"snapshotting"`
-	Filesystems  FilesystemsFilter `yaml:"filesystems"`
-	Send         *SendOptions      `yaml:"send,fromdefaults,optional"`
+	ActiveJob     `yaml:",inline"`
+	Snapshotting  SnapshottingEnum  `yaml:"snapshotting"`
+	Filesystems   FilesystemsFilter `yaml:"filesystems"`
+	Send          *SendOptions      `yaml:"send,fromdefaults,optional"`
+	JobSnapPrefix string            `yaml:"replication_snapshots_prefix,optional"`
 }
 
 func (j *PushJob) GetFilesystems() FilesystemsFilter { return j.Filesystems }
 func (j *PushJob) GetSendOptions() *SendOptions      { return j.Send }
+func (j *PushJob) GetJobSnapPrefix() string          { return j.JobSnapPrefix }
 
 type PullJob struct {
 	ActiveJob `yaml:",inline"`
@@ -185,14 +187,16 @@ func (j *SinkJob) GetAppendClientIdentity() bool { return true }
 func (j *SinkJob) GetRecvOptions() *RecvOptions  { return j.Recv }
 
 type SourceJob struct {
-	PassiveJob   `yaml:",inline"`
-	Snapshotting SnapshottingEnum  `yaml:"snapshotting"`
-	Filesystems  FilesystemsFilter `yaml:"filesystems"`
-	Send         *SendOptions      `yaml:"send,optional,fromdefaults"`
+	PassiveJob    `yaml:",inline"`
+	Snapshotting  SnapshottingEnum  `yaml:"snapshotting"`
+	Filesystems   FilesystemsFilter `yaml:"filesystems"`
+	Send          *SendOptions      `yaml:"send,optional,fromdefaults"`
+	JobSnapPrefix string            `yaml:"replication_snapshots_prefix,optional"`
 }
 
 func (j *SourceJob) GetFilesystems() FilesystemsFilter { return j.Filesystems }
 func (j *SourceJob) GetSendOptions() *SendOptions      { return j.Send }
+func (j *SourceJob) GetJobSnapPrefix() string          { return j.JobSnapPrefix }
 
 type FilesystemsFilter map[string]bool
 

--- a/config/samples/push.yml
+++ b/config/samples/push.yml
@@ -1,6 +1,7 @@
 jobs:
   - type: push
     name: "push"
+    replication_snapshots_prefix: zrepl_
     filesystems: {
       "<": true,
       "tmp": false

--- a/config/samples/source.yml
+++ b/config/samples/source.yml
@@ -1,6 +1,7 @@
 jobs:
 - name: pull_source
   type: source
+  replication_snapshots_prefix: zrepl_
   serve:
     type: tcp
     listen: "0.0.0.0:8888"

--- a/daemon/job/build_jobs_sendrecvoptions.go
+++ b/daemon/job/build_jobs_sendrecvoptions.go
@@ -13,6 +13,7 @@ import (
 type SendingJobConfig interface {
 	GetFilesystems() config.FilesystemsFilter
 	GetSendOptions() *config.SendOptions // must not be nil
+	GetJobSnapPrefix() string
 }
 
 func buildSenderConfig(in SendingJobConfig, jobID endpoint.JobID) (*endpoint.SenderConfig, error) {
@@ -23,8 +24,9 @@ func buildSenderConfig(in SendingJobConfig, jobID endpoint.JobID) (*endpoint.Sen
 	}
 	sendOpts := in.GetSendOptions()
 	return &endpoint.SenderConfig{
-		FSF:   fsf,
-		JobID: jobID,
+		FSF:           fsf,
+		JobID:         jobID,
+		JobSnapPrefix: in.GetJobSnapPrefix(),
 
 		Encrypt:              &nodefault.Bool{B: sendOpts.Encrypted},
 		SendRaw:              sendOpts.Raw,

--- a/daemon/snapper/snapper.go
+++ b/daemon/snapper/snapper.go
@@ -472,8 +472,8 @@ var findSyncPointFSNoFilesystemVersionsErr = fmt.Errorf("no filesystem versions"
 func findSyncPointFSNextOptimalSnapshotTime(ctx context.Context, now time.Time, interval time.Duration, prefix string, d *zfs.DatasetPath) (time.Time, error) {
 
 	fsvs, err := zfs.ZFSListFilesystemVersions(ctx, d, zfs.ListFilesystemVersionsOptions{
-		Types:           zfs.Snapshots,
-		ShortnamePrefix: prefix,
+		Types:      zfs.Snapshots,
+		SnapPrefix: prefix,
 	})
 	if err != nil {
 		return time.Time{}, errors.Wrap(err, "list filesystem versions")

--- a/docs/configuration/jobs.rst
+++ b/docs/configuration/jobs.rst
@@ -28,6 +28,8 @@ Job Type ``push``
       - |send-options| 
     * - ``snapshotting``
       - |snapshotting-spec|
+    * - ``replication_snapshots_prefix``
+      - |replication-snapshots-prefix|
     * - ``pruning``
       - |pruning-spec|
 
@@ -107,6 +109,9 @@ Job Type ``source``
       - |send-options| 
     * - ``snapshotting``
       - |snapshotting-spec|
+    * - ``replication_snapshots_prefix``
+      - |replication-snapshots-prefix|
+
 
 Example config: :sampleconf:`/source.yml`
 

--- a/docs/global.rst.inc
+++ b/docs/global.rst.inc
@@ -28,6 +28,7 @@
 .. |snapshotting-spec| replace:: :ref:`snapshotting specification <job-snapshotting-spec>`
 .. |pruning-spec| replace:: :ref:`pruning specification <prune>`
 .. |filter-spec| replace:: :ref:`filter specification<pattern-filter>`
+.. |replication-snapshots-prefix| replace:: :ref:`filters the snapshots to be replicate based on the provided prefix. Matching this prefix with the snapshotting<job-snapshotting-spec> prefix could allow to replicate only the snapshots created by zrepl`
 
 .. |br| raw:: html
 

--- a/docs/global.rst.inc
+++ b/docs/global.rst.inc
@@ -28,7 +28,7 @@
 .. |snapshotting-spec| replace:: :ref:`snapshotting specification <job-snapshotting-spec>`
 .. |pruning-spec| replace:: :ref:`pruning specification <prune>`
 .. |filter-spec| replace:: :ref:`filter specification<pattern-filter>`
-.. |replication-snapshots-prefix| replace:: :ref:`filters the snapshots to be replicate based on the provided prefix. Matching this prefix with the snapshotting<job-snapshotting-spec> prefix could allow to replicate only the snapshots created by zrepl`
+.. |replication-snapshots-prefix| replace:: :ref:filters the snapshots to be replicate based on the provided prefix, matching this prefix with the `snapshotting<job-snapshotting-spec>` prefix could allow to replicate only the snapshots created by zrepl
 
 .. |br| raw:: html
 

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -119,7 +119,7 @@ func (s *Sender) ListFilesystemVersions(ctx context.Context, r *pdu.ListFilesyst
 	}
 
 	fsvs, err := zfs.ZFSListFilesystemVersions(ctx, lp, zfs.ListFilesystemVersionsOptions{
-		ShortnamePrefix: s.config.JobSnapPrefix,
+		SnapPrefix: s.config.JobSnapPrefix,
 	})
 
 	if err != nil {

--- a/endpoint/endpoint.go
+++ b/endpoint/endpoint.go
@@ -23,8 +23,9 @@ import (
 )
 
 type SenderConfig struct {
-	FSF   zfs.DatasetFilter
-	JobID JobID
+	FSF           zfs.DatasetFilter
+	JobID         JobID
+	JobSnapPrefix string
 
 	Encrypt              *nodefault.Bool
 	SendRaw              bool
@@ -116,7 +117,11 @@ func (s *Sender) ListFilesystemVersions(ctx context.Context, r *pdu.ListFilesyst
 	if err != nil {
 		return nil, err
 	}
-	fsvs, err := zfs.ZFSListFilesystemVersions(ctx, lp, zfs.ListFilesystemVersionsOptions{})
+
+	fsvs, err := zfs.ZFSListFilesystemVersions(ctx, lp, zfs.ListFilesystemVersionsOptions{
+		ShortnamePrefix: s.config.JobSnapPrefix,
+	})
+
 	if err != nil {
 		return nil, err
 	}

--- a/platformtest/tests/listFilesystemVersions.go
+++ b/platformtest/tests/listFilesystemVersions.go
@@ -66,7 +66,7 @@ func ListFilesystemVersionsTypeFilteringAndPrefix(t *platformtest.Context) {
 
 	// just with prefix foo
 	vs, err = zfs.ZFSListFilesystemVersions(t, mustDatasetPath(fs), zfs.ListFilesystemVersionsOptions{
-		ShortnamePrefix: "foo",
+		SnapPrefix: "foo",
 	})
 	require.NoError(t, err)
 	require.Equal(t, []string{"#foo 1", "#foo 2", "@foo 1", "@foo 2"}, versionRelnamesSorted(vs))

--- a/zfs/versions.go
+++ b/zfs/versions.go
@@ -211,6 +211,13 @@ func (o *ListFilesystemVersionsOptions) typesFlagArgs() string {
 }
 
 func (o *ListFilesystemVersionsOptions) matches(v FilesystemVersion) bool {
+	// Workaround when using JobSnapPrefix because bookmarks are not following
+	// the snapshotting prefix but they have fixed prefix:
+	// replicationCursorBookmarkNamePrefix = "zrepl_CURSOR"
+	if len(o.ShortnamePrefix) > 0 && len(o.Types) == 0 && v.Type == Bookmark && strings.HasPrefix(v.Name, "zrepl_CURSOR") {
+		return true
+	}
+
 	return (len(o.Types) == 0 || o.Types[v.Type]) && strings.HasPrefix(v.Name, o.ShortnamePrefix)
 }
 

--- a/zfs/versions.go
+++ b/zfs/versions.go
@@ -195,7 +195,7 @@ func ParseFilesystemVersion(args ParseFilesystemVersionArgs) (v FilesystemVersio
 type ListFilesystemVersionsOptions struct {
 	// the prefix of the version name, without the delimiter char
 	// empty means any prefix matches
-	ShortnamePrefix string
+	SnapPrefix string
 
 	// which types should be returned
 	// nil or len(0) means any prefix matches
@@ -211,14 +211,11 @@ func (o *ListFilesystemVersionsOptions) typesFlagArgs() string {
 }
 
 func (o *ListFilesystemVersionsOptions) matches(v FilesystemVersion) bool {
-	// Workaround when using JobSnapPrefix because bookmarks are not following
-	// the snapshotting prefix but they have fixed prefix:
-	// replicationCursorBookmarkNamePrefix = "zrepl_CURSOR"
-	if len(o.ShortnamePrefix) > 0 && len(o.Types) == 0 && v.Type == Bookmark && strings.HasPrefix(v.Name, "zrepl_CURSOR") {
+	if v.Type == Bookmark {
 		return true
 	}
 
-	return (len(o.Types) == 0 || o.Types[v.Type]) && strings.HasPrefix(v.Name, o.ShortnamePrefix)
+	return (len(o.Types) == 0 || o.Types[v.Type]) && strings.HasPrefix(v.Name, o.SnapPrefix)
 }
 
 // returned versions are sorted by createtxg FIXME drop sort by createtxg requirement


### PR DESCRIPTION
This PR will allow job snapshots prefix for replication filtering.

Added optional parameter replication_snapshots_prefix that will tell zrepl to replicate only snapshots with the prefix provided, it is configurable only for push and source jobs and will be filtering the snapshots from the sender side. If not used zrepl will keep working as it used to replicating every snapshot created in the filesystem.

zrepl.yml syntax example:

-  type: push
   replication_snapshots_prefix: “zrepl_”
   …

Should address https://github.com/zrepl/zrepl/issues/403

Please give it a try and see if it helps
