### PR TITLE
Signal decoupling

### DIFF
--- a/client/signal.go
+++ b/client/signal.go
@@ -11,8 +11,8 @@ import (
 )
 
 var SignalCmd = &cli.Subcommand{
-	Use:   "signal [wakeup|reset|snapshot] JOB",
-	Short: "wake up a job from wait state, abort its current invocation, run a snapshot job",
+	Use:   "signal [wakeup|snapshot|prune|reset] JOB",
+	Short: "wake up a job from wait state, run a snapshot job, run a prune job, abort its current invocation",
 	Run: func(ctx context.Context, subcommand *cli.Subcommand, args []string) error {
 		return runSignalCmd(subcommand.Config(), args)
 	},
@@ -20,7 +20,7 @@ var SignalCmd = &cli.Subcommand{
 
 func runSignalCmd(config *config.Config, args []string) error {
 	if len(args) != 2 {
-		return errors.Errorf("Expected 2 arguments: [wakeup|reset|snapshot] JOB")
+		return errors.Errorf("Expected 2 arguments: [wakeup|snapshot|prune|reset] JOB")
 	}
 
 	httpc, err := controlHttpClient(config.Global.Control.SockPath)

--- a/client/signal.go
+++ b/client/signal.go
@@ -11,8 +11,8 @@ import (
 )
 
 var SignalCmd = &cli.Subcommand{
-	Use:   "signal [wakeup|snapshot|prune|reset] JOB",
-	Short: "wake up a job from wait state, run a snapshot job, run a prune job, abort its current invocation",
+	Use:   "signal [replicate|snapshot|prune|reset] JOB",
+	Short: "replicate a job, run a snapshot job, run a prune job, abort its current invocation",
 	Run: func(ctx context.Context, subcommand *cli.Subcommand, args []string) error {
 		return runSignalCmd(subcommand.Config(), args)
 	},
@@ -20,7 +20,7 @@ var SignalCmd = &cli.Subcommand{
 
 func runSignalCmd(config *config.Config, args []string) error {
 	if len(args) != 2 {
-		return errors.Errorf("Expected 2 arguments: [wakeup|snapshot|prune|reset] JOB")
+		return errors.Errorf("Expected 2 arguments: [replicate|snapshot|prune|reset] JOB")
 	}
 
 	httpc, err := controlHttpClient(config.Global.Control.SockPath)

--- a/client/signal.go
+++ b/client/signal.go
@@ -11,8 +11,8 @@ import (
 )
 
 var SignalCmd = &cli.Subcommand{
-	Use:   "signal [replicate|snapshot|prune|reset] JOB",
-	Short: "replicate a job, run a snapshot job, run a prune job, abort its current invocation",
+	Use:   "signal [snapshot|replicate|prune|reset] JOB",
+	Short: "run a snapshot job, replicate a job, run a prune job, abort its current invocation",
 	Run: func(ctx context.Context, subcommand *cli.Subcommand, args []string) error {
 		return runSignalCmd(subcommand.Config(), args)
 	},
@@ -20,7 +20,7 @@ var SignalCmd = &cli.Subcommand{
 
 func runSignalCmd(config *config.Config, args []string) error {
 	if len(args) != 2 {
-		return errors.Errorf("Expected 2 arguments: [replicate|snapshot|prune|reset] JOB")
+		return errors.Errorf("Expected 2 arguments: [snapshot|replicate|prune|reset] JOB")
 	}
 
 	httpc, err := controlHttpClient(config.Global.Control.SockPath)

--- a/client/signal.go
+++ b/client/signal.go
@@ -11,8 +11,8 @@ import (
 )
 
 var SignalCmd = &cli.Subcommand{
-	Use:   "signal [wakeup|reset] JOB",
-	Short: "wake up a job from wait state or abort its current invocation",
+	Use:   "signal [wakeup|reset|snapshot] JOB",
+	Short: "wake up a job from wait state, abort its current invocation, run a snapshot job",
 	Run: func(ctx context.Context, subcommand *cli.Subcommand, args []string) error {
 		return runSignalCmd(subcommand.Config(), args)
 	},
@@ -20,7 +20,7 @@ var SignalCmd = &cli.Subcommand{
 
 func runSignalCmd(config *config.Config, args []string) error {
 	if len(args) != 2 {
-		return errors.Errorf("Expected 2 arguments: [wakeup|reset] JOB")
+		return errors.Errorf("Expected 2 arguments: [wakeup|reset|snapshot] JOB")
 	}
 
 	httpc, err := controlHttpClient(config.Global.Control.SockPath)

--- a/client/status/client/client.go
+++ b/client/status/client/client.go
@@ -63,6 +63,10 @@ func (c *Client) SignalSnapshot(job string) error {
 	return c.signal(job, "snapshot")
 }
 
+func (c *Client) SignalPrune(job string) error {
+	return c.signal(job, "prune")
+}
+
 func (c *Client) SignalReset(job string) error {
 	return c.signal(job, "reset")
 }

--- a/client/status/client/client.go
+++ b/client/status/client/client.go
@@ -55,8 +55,8 @@ func (c *Client) signal(job, sig string) error {
 	)
 }
 
-func (c *Client) SignalWakeup(job string) error {
-	return c.signal(job, "wakeup")
+func (c *Client) SignalReplicate(job string) error {
+	return c.signal(job, "replicate")
 }
 
 func (c *Client) SignalSnapshot(job string) error {

--- a/client/status/client/client.go
+++ b/client/status/client/client.go
@@ -59,6 +59,10 @@ func (c *Client) SignalWakeup(job string) error {
 	return c.signal(job, "wakeup")
 }
 
+func (c *Client) SignalSnapshot(job string) error {
+	return c.signal(job, "snapshot")
+}
+
 func (c *Client) SignalReset(job string) error {
 	return c.signal(job, "reset")
 }

--- a/client/status/status.go
+++ b/client/status/status.go
@@ -19,7 +19,7 @@ import (
 type Client interface {
 	Status() (daemon.Status, error)
 	StatusRaw() ([]byte, error)
-	SignalWakeup(job string) error
+	SignalReplicate(job string) error
 	SignalSnapshot(job string) error
 	SignalPrune(job string) error
 	SignalReset(job string) error

--- a/client/status/status.go
+++ b/client/status/status.go
@@ -20,6 +20,7 @@ type Client interface {
 	Status() (daemon.Status, error)
 	StatusRaw() ([]byte, error)
 	SignalWakeup(job string) error
+	SignalSnapshot(job string) error
 	SignalReset(job string) error
 }
 

--- a/client/status/status.go
+++ b/client/status/status.go
@@ -21,6 +21,7 @@ type Client interface {
 	StatusRaw() ([]byte, error)
 	SignalWakeup(job string) error
 	SignalSnapshot(job string) error
+	SignalPrune(job string) error
 	SignalReset(job string) error
 }
 

--- a/client/status/status_interactive.go
+++ b/client/status/status_interactive.go
@@ -281,8 +281,8 @@ func interactive(c Client, flag statusFlags) error {
 			if !ok {
 				return nil
 			}
-			signals := []string{"wakeup", "snapshot", "reset"}
-			clientFuncs := []func(job string) error{c.SignalWakeup, c.SignalSnapshot, c.SignalReset}
+			signals := []string{"wakeup", "snapshot", "prune", "reset"}
+			clientFuncs := []func(job string) error{c.SignalWakeup, c.SignalSnapshot, c.SignalPrune, c.SignalReset}
 			sigMod := tview.NewModal()
 			sigMod.SetBackgroundColor(tcell.ColorDefault)
 			sigMod.SetBorder(true)

--- a/client/status/status_interactive.go
+++ b/client/status/status_interactive.go
@@ -281,8 +281,8 @@ func interactive(c Client, flag statusFlags) error {
 			if !ok {
 				return nil
 			}
-			signals := []string{"replicate", "snapshot", "prune", "reset"}
-			clientFuncs := []func(job string) error{c.SignalReplicate, c.SignalSnapshot, c.SignalPrune, c.SignalReset}
+			signals := []string{"snapshot", "replicate", "prune", "reset"}
+			clientFuncs := []func(job string) error{c.SignalSnapshot, c.SignalReplicate, c.SignalPrune, c.SignalReset}
 			sigMod := tview.NewModal()
 			sigMod.SetBackgroundColor(tcell.ColorDefault)
 			sigMod.SetBorder(true)

--- a/client/status/status_interactive.go
+++ b/client/status/status_interactive.go
@@ -281,8 +281,8 @@ func interactive(c Client, flag statusFlags) error {
 			if !ok {
 				return nil
 			}
-			signals := []string{"wakeup", "snapshot", "prune", "reset"}
-			clientFuncs := []func(job string) error{c.SignalWakeup, c.SignalSnapshot, c.SignalPrune, c.SignalReset}
+			signals := []string{"replicate", "snapshot", "prune", "reset"}
+			clientFuncs := []func(job string) error{c.SignalReplicate, c.SignalSnapshot, c.SignalPrune, c.SignalReset}
 			sigMod := tview.NewModal()
 			sigMod.SetBackgroundColor(tcell.ColorDefault)
 			sigMod.SetBorder(true)

--- a/client/status/status_interactive.go
+++ b/client/status/status_interactive.go
@@ -281,8 +281,8 @@ func interactive(c Client, flag statusFlags) error {
 			if !ok {
 				return nil
 			}
-			signals := []string{"wakeup", "reset"}
-			clientFuncs := []func(job string) error{c.SignalWakeup, c.SignalReset}
+			signals := []string{"wakeup", "snapshot", "reset"}
+			clientFuncs := []func(job string) error{c.SignalWakeup, c.SignalSnapshot, c.SignalReset}
 			sigMod := tview.NewModal()
 			sigMod.SetBackgroundColor(tcell.ColorDefault)
 			sigMod.SetBorder(true)

--- a/config/samples/quickstart_backup_to_external_disk.yml
+++ b/config/samples/quickstart_backup_to_external_disk.yml
@@ -40,7 +40,7 @@ jobs:
 
 # This job pushes to the local sink defined in job `backuppool_sink`.
 # We trigger replication manually from the command line / udev rules using
-#  `zrepl signal wakeup push_to_drive`
+#  `zrepl signal replicate push_to_drive`
 - type: push
   name: push_to_drive
   connect:

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -149,6 +149,8 @@ func (j *controlJob) Run(ctx context.Context) {
 				err = j.jobs.reset(req.Name)
 			case "snapshot":
 				err = j.jobs.dosnapshot(req.Name)
+			case "prune":
+				err = j.jobs.doprune(req.Name)
 			default:
 				err = fmt.Errorf("operation %q is invalid", req.Op)
 			}

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -143,14 +143,14 @@ func (j *controlJob) Run(ctx context.Context) {
 
 			var err error
 			switch req.Op {
-			case "wakeup":
-				err = j.jobs.wakeup(req.Name)
-			case "reset":
-				err = j.jobs.reset(req.Name)
+			case "replicate":
+				err = j.jobs.doreplicate(req.Name)
 			case "snapshot":
 				err = j.jobs.dosnapshot(req.Name)
 			case "prune":
 				err = j.jobs.doprune(req.Name)
+			case "reset":
+				err = j.jobs.reset(req.Name)
 			default:
 				err = fmt.Errorf("operation %q is invalid", req.Op)
 			}

--- a/daemon/control.go
+++ b/daemon/control.go
@@ -147,6 +147,8 @@ func (j *controlJob) Run(ctx context.Context) {
 				err = j.jobs.wakeup(req.Name)
 			case "reset":
 				err = j.jobs.reset(req.Name)
+			case "snapshot":
+				err = j.jobs.dosnapshot(req.Name)
 			default:
 				err = fmt.Errorf("operation %q is invalid", req.Op)
 			}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/zrepl/zrepl/config"
 	"github.com/zrepl/zrepl/daemon/job"
+	"github.com/zrepl/zrepl/daemon/job/dosnapshot"
 	"github.com/zrepl/zrepl/daemon/job/reset"
 	"github.com/zrepl/zrepl/daemon/job/wakeup"
 	"github.com/zrepl/zrepl/daemon/logging"
@@ -131,17 +132,19 @@ type jobs struct {
 	wg sync.WaitGroup
 
 	// m protects all fields below it
-	m       sync.RWMutex
-	wakeups map[string]wakeup.Func // by Job.Name
-	resets  map[string]reset.Func  // by Job.Name
-	jobs    map[string]job.Job
+	m           sync.RWMutex
+	wakeups     map[string]wakeup.Func     // by Job.Name
+	resets      map[string]reset.Func      // by Job.Name
+	dosnapshots map[string]dosnapshot.Func // by Job.Name
+	jobs        map[string]job.Job
 }
 
 func newJobs() *jobs {
 	return &jobs{
-		wakeups: make(map[string]wakeup.Func),
-		resets:  make(map[string]reset.Func),
-		jobs:    make(map[string]job.Job),
+		wakeups:     make(map[string]wakeup.Func),
+		resets:      make(map[string]reset.Func),
+		dosnapshots: make(map[string]dosnapshot.Func),
+		jobs:        make(map[string]job.Job),
 	}
 }
 
@@ -212,6 +215,17 @@ func (s *jobs) reset(job string) error {
 	return wu()
 }
 
+func (s *jobs) dosnapshot(job string) error {
+	s.m.RLock()
+	defer s.m.RUnlock()
+
+	wu, ok := s.dosnapshots[job]
+	if !ok {
+		return errors.Errorf("Job %s does not exist", job)
+	}
+	return wu()
+}
+
 const (
 	jobNamePrometheus = "_prometheus"
 	jobNameControl    = "_control"
@@ -244,8 +258,10 @@ func (s *jobs) start(ctx context.Context, j job.Job, internal bool) {
 	ctx = zfscmd.WithJobID(ctx, j.Name())
 	ctx, wakeup := wakeup.Context(ctx)
 	ctx, resetFunc := reset.Context(ctx)
+	ctx, dosnapshotFunc := dosnapshot.Context(ctx)
 	s.wakeups[jobName] = wakeup
 	s.resets[jobName] = resetFunc
+	s.dosnapshots[jobName] = dosnapshotFunc
 
 	s.wg.Add(1)
 	go func() {

--- a/daemon/job/active.go
+++ b/daemon/job/active.go
@@ -16,8 +16,8 @@ import (
 
 	"github.com/zrepl/zrepl/config"
 	"github.com/zrepl/zrepl/daemon/job/doprune"
+	"github.com/zrepl/zrepl/daemon/job/doreplicate"
 	"github.com/zrepl/zrepl/daemon/job/reset"
-	"github.com/zrepl/zrepl/daemon/job/wakeup"
 	"github.com/zrepl/zrepl/daemon/pruner"
 	"github.com/zrepl/zrepl/daemon/snapper"
 	"github.com/zrepl/zrepl/endpoint"
@@ -448,7 +448,7 @@ outer:
 			j.doPrune(invocationCtx)
 			endSpan()
 
-		case <-wakeup.Wait(ctx):
+		case <-doreplicate.Wait(ctx):
 			j.mode.ResetConnectBackoff()
 
 			invocationCount++

--- a/daemon/job/doprune/doprune.go
+++ b/daemon/job/doprune/doprune.go
@@ -1,4 +1,4 @@
-package wakeup
+package doprune
 
 import (
 	"context"
@@ -7,10 +7,10 @@ import (
 
 type contextKey int
 
-const contextKeyWakeup contextKey = iota
+const contextKeyDoprune contextKey = iota
 
 func Wait(ctx context.Context) <-chan struct{} {
-	wc, ok := ctx.Value(contextKeyWakeup).(chan struct{})
+	wc, ok := ctx.Value(contextKeyDoprune).(chan struct{})
 	if !ok {
 		wc = make(chan struct{})
 	}
@@ -19,7 +19,7 @@ func Wait(ctx context.Context) <-chan struct{} {
 
 type Func func() error
 
-var AlreadyWokenUp = errors.New("Cannot wakeup")
+var AlreadyDoprune = errors.New("Cannot start pruning")
 
 func Context(ctx context.Context) (context.Context, Func) {
 	wc := make(chan struct{})
@@ -28,8 +28,8 @@ func Context(ctx context.Context) (context.Context, Func) {
 		case wc <- struct{}{}:
 			return nil
 		default:
-			return AlreadyWokenUp
+			return AlreadyDoprune
 		}
 	}
-	return context.WithValue(ctx, contextKeyWakeup, wc), wuf
+	return context.WithValue(ctx, contextKeyDoprune, wc), wuf
 }

--- a/daemon/job/doreplicate/doreplicate.go
+++ b/daemon/job/doreplicate/doreplicate.go
@@ -1,4 +1,4 @@
-package wakeup
+package doreplicate
 
 import (
 	"context"
@@ -7,10 +7,10 @@ import (
 
 type contextKey int
 
-const contextKeyWakeup contextKey = iota
+const contextKeyReplicate contextKey = iota
 
 func Wait(ctx context.Context) <-chan struct{} {
-	wc, ok := ctx.Value(contextKeyWakeup).(chan struct{})
+	wc, ok := ctx.Value(contextKeyReplicate).(chan struct{})
 	if !ok {
 		wc = make(chan struct{})
 	}
@@ -19,7 +19,7 @@ func Wait(ctx context.Context) <-chan struct{} {
 
 type Func func() error
 
-var AlreadyWokenUp = errors.New("Cannot wakeup")
+var AlreadyReplicate = errors.New("Cannot start replication")
 
 func Context(ctx context.Context) (context.Context, Func) {
 	wc := make(chan struct{})
@@ -28,8 +28,8 @@ func Context(ctx context.Context) (context.Context, Func) {
 		case wc <- struct{}{}:
 			return nil
 		default:
-			return AlreadyWokenUp
+			return AlreadyReplicate
 		}
 	}
-	return context.WithValue(ctx, contextKeyWakeup, wc), wuf
+	return context.WithValue(ctx, contextKeyReplicate, wc), wuf
 }

--- a/daemon/job/dosnapshot/dosnapshot.go
+++ b/daemon/job/dosnapshot/dosnapshot.go
@@ -1,0 +1,35 @@
+package dosnapshot
+
+import (
+	"context"
+	"errors"
+)
+
+type contextKey int
+
+const contextKeyDosnapshot contextKey = iota
+
+func Wait(ctx context.Context) <-chan struct{} {
+	wc, ok := ctx.Value(contextKeyDosnapshot).(chan struct{})
+	if !ok {
+		wc = make(chan struct{})
+	}
+	return wc
+}
+
+type Func func() error
+
+var AlreadyDosnapshot = errors.New("already snapshotting")
+
+func Context(ctx context.Context) (context.Context, Func) {
+	wc := make(chan struct{})
+	wuf := func() error {
+		select {
+		case wc <- struct{}{}:
+			return nil
+		default:
+			return AlreadyDosnapshot
+		}
+	}
+	return context.WithValue(ctx, contextKeyDosnapshot, wc), wuf
+}

--- a/daemon/job/dosnapshot/dosnapshot.go
+++ b/daemon/job/dosnapshot/dosnapshot.go
@@ -19,7 +19,7 @@ func Wait(ctx context.Context) <-chan struct{} {
 
 type Func func() error
 
-var AlreadyDosnapshot = errors.New("already snapshotting")
+var AlreadyDosnapshot = errors.New("Cannot start snapshotting")
 
 func Context(ctx context.Context) (context.Context, Func) {
 	wc := make(chan struct{})

--- a/daemon/job/reset/reset.go
+++ b/daemon/job/reset/reset.go
@@ -19,7 +19,7 @@ func Wait(ctx context.Context) <-chan struct{} {
 
 type Func func() error
 
-var AlreadyReset = errors.New("already reset")
+var AlreadyReset = errors.New("Cannot reset")
 
 func Context(ctx context.Context) (context.Context, Func) {
 	wc := make(chan struct{})

--- a/daemon/job/snapjob.go
+++ b/daemon/job/snapjob.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/zrepl/zrepl/config"
 	"github.com/zrepl/zrepl/daemon/filters"
-	"github.com/zrepl/zrepl/daemon/job/wakeup"
+	"github.com/zrepl/zrepl/daemon/job/doprune"
 	"github.com/zrepl/zrepl/daemon/pruner"
 	"github.com/zrepl/zrepl/daemon/snapper"
 	"github.com/zrepl/zrepl/endpoint"
@@ -118,7 +118,7 @@ outer:
 			log.WithError(ctx.Err()).Info("context")
 			break outer
 
-		case <-wakeup.Wait(ctx):
+		case <-doprune.Wait(ctx):
 		case <-periodicDone:
 		}
 		invocationCount++

--- a/daemon/snapper/snapper.go
+++ b/daemon/snapper/snapper.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/zrepl/zrepl/daemon/job/dosnapshot"
 	"github.com/zrepl/zrepl/daemon/logging/trace"
 
 	"github.com/zrepl/zrepl/config"
@@ -210,6 +211,10 @@ func syncUp(a args, u updater) state {
 		return u(func(s *Snapper) {
 			s.state = Planning
 		}).sf()
+	case <-dosnapshot.Wait(a.ctx):
+		return u(func(s *Snapper) {
+			s.state = Planning
+		}).sf()
 	case <-a.ctx.Done():
 		return onMainCtxDone(a.ctx, u)
 	}
@@ -375,6 +380,10 @@ func wait(a args, u updater) state {
 
 	select {
 	case <-t.C:
+		return u(func(snapper *Snapper) {
+			snapper.state = Planning
+		}).sf()
+	case <-dosnapshot.Wait(a.ctx):
 		return u(func(snapper *Snapper) {
 			snapper.state = Planning
 		}).sf()

--- a/daemon/snapper/snapper.go
+++ b/daemon/snapper/snapper.go
@@ -62,6 +62,8 @@ type Snapper struct {
 	mtx   sync.Mutex
 	state State
 
+	signal_dosnapshot bool
+
 	// set in state Plan, used in Waiting
 	lastInvocation time.Time
 
@@ -210,10 +212,12 @@ func syncUp(a args, u updater) state {
 	case <-t.C:
 		return u(func(s *Snapper) {
 			s.state = Planning
+			s.signal_dosnapshot = false
 		}).sf()
 	case <-dosnapshot.Wait(a.ctx):
 		return u(func(s *Snapper) {
 			s.state = Planning
+			s.signal_dosnapshot = true
 		}).sf()
 	case <-a.ctx.Done():
 		return onMainCtxDone(a.ctx, u)
@@ -329,11 +333,19 @@ func snapshot(a args, u updater) state {
 		})
 	}
 
-	select {
-	case a.snapshotsTaken <- struct{}{}:
-	default:
-		if a.snapshotsTaken != nil {
-			getLogger(a.ctx).Warn("callback channel is full, discarding snapshot update event")
+	var signal_dosnapshot bool
+	u(func(snapper *Snapper) {
+		signal_dosnapshot = snapper.signal_dosnapshot
+	})
+
+	if !signal_dosnapshot {
+		select {
+		// this will start Replication & Pruning
+		case a.snapshotsTaken <- struct{}{}:
+		default:
+			if a.snapshotsTaken != nil {
+				getLogger(a.ctx).Warn("callback channel is full, discarding snapshot update event")
+			}
 		}
 	}
 
@@ -382,10 +394,12 @@ func wait(a args, u updater) state {
 	case <-t.C:
 		return u(func(snapper *Snapper) {
 			snapper.state = Planning
+			snapper.signal_dosnapshot = false
 		}).sf()
 	case <-dosnapshot.Wait(a.ctx):
-		return u(func(snapper *Snapper) {
-			snapper.state = Planning
+		return u(func(s *Snapper) {
+			s.state = Planning
+			s.signal_dosnapshot = true
 		}).sf()
 	case <-a.ctx.Done():
 		return onMainCtxDone(a.ctx, u)


### PR DESCRIPTION
Changed zrepl cli signaling decoupling the signals for each task, snapshot, replicate, prune and reset.

$ zrepl [snapshot|replicate|prune|reset] JOB

Added the same signals in the zrepl status GUI.

Every signal will just do what it says, nothing more, as an example the snapshot signal will just do snapshots and won’t trigger replication nor pruning.

Should address https://github.com/zrepl/zrepl/issues/451

It took me a while to figure out how zrepl works with the signaling and I had to change quite a few files, hopefully I haven’t missed anything.
Let me know what you think.
