### PR TITLE
introduce conflict_resolution.initial_replication.replicate_all_snapshots

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -54,12 +54,21 @@ func (j JobEnum) Name() string {
 }
 
 type ActiveJob struct {
-	Type        string                `yaml:"type"`
-	Name        string                `yaml:"name"`
-	Connect     ConnectEnum           `yaml:"connect"`
-	Pruning     PruningSenderReceiver `yaml:"pruning"`
-	Debug       JobDebugSettings      `yaml:"debug,optional"`
-	Replication *Replication          `yaml:"replication,optional,fromdefaults"`
+	Type               string                `yaml:"type"`
+	Name               string                `yaml:"name"`
+	Connect            ConnectEnum           `yaml:"connect"`
+	Pruning            PruningSenderReceiver `yaml:"pruning"`
+	Debug              JobDebugSettings      `yaml:"debug,optional"`
+	Replication        *Replication          `yaml:"replication,optional,fromdefaults"`
+	ConflictResolution *ConflictResolution   `yaml:"conflict_resolution,optional,fromdefaults"`
+}
+
+type ConflictResolution struct {
+	InitialReplication *ConflictResolutionOptionsInitialReplication `yaml:"initial_replication,optional,fromdefaults"`
+}
+
+type ConflictResolutionOptionsInitialReplication struct {
+	ReplicateAllSnapshots bool `yaml:"replicate_all_snapshots,optional,default=false"`
 }
 
 type PassiveJob struct {

--- a/daemon/job/active.go
+++ b/daemon/job/active.go
@@ -163,6 +163,7 @@ func modePushFromConfig(g *config.Global, in *config.PushJob, jobID endpoint.Job
 
 	m.plannerPolicy = &logic.PlannerPolicy{
 		EncryptedSend:             logic.TriFromBool(in.Send.Encrypted),
+		InitiallyAllSnapshots:     in.ConflictResolution.InitialReplication.ReplicateAllSnapshots,
 		ReplicationConfig:         replicationConfig,
 		SizeEstimationConcurrency: in.Replication.Concurrency.SizeEstimates,
 	}
@@ -262,6 +263,7 @@ func modePullFromConfig(g *config.Global, in *config.PullJob, jobID endpoint.Job
 
 	m.plannerPolicy = &logic.PlannerPolicy{
 		EncryptedSend:             logic.DontCare,
+		InitiallyAllSnapshots:     in.ConflictResolution.InitialReplication.ReplicateAllSnapshots,
 		ReplicationConfig:         replicationConfig,
 		SizeEstimationConcurrency: in.Replication.Concurrency.SizeEstimates,
 	}

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -13,6 +13,7 @@ Configuration
     configuration/filter_syntax
     configuration/sendrecvoptions
     configuration/replication
+    configuration/conflict_resolution
     configuration/snapshotting
     configuration/prune
     configuration/logging

--- a/docs/configuration/conflict_resolution.rst
+++ b/docs/configuration/conflict_resolution.rst
@@ -1,0 +1,27 @@
+.. include:: ../global.rst.inc
+
+
+Conflict Resolution Options
+===========================
+
+
+::
+
+   jobs:
+   - type: push
+     filesystems: ...
+     conflict_resolution:
+       initial_replication:
+           send_all_snapshots: false # false,true
+
+     ...
+
+.. _conflict_resolution-initial_replication-option-send_all_snapshots:
+
+
+``send_all_snapshots`` option
+-----------------------------
+
+The ``send_all_snapshots`` options control the initial transfer of push and pull jobs.
+Left ``false`` (the default), the initial transfer will only transfer the most recent snapshot.
+If ``send_all_snapshots`` is ``true`` for the very first transfer of a dataset, all historical snapshots will be transfered.

--- a/replication/logic/replication_logic_policy.go
+++ b/replication/logic/replication_logic_policy.go
@@ -10,6 +10,7 @@ import (
 
 type PlannerPolicy struct {
 	EncryptedSend             tri // all sends must be encrypted (send -w, and encryption!=off)
+	InitiallyAllSnapshots     bool
 	ReplicationConfig         *pdu.ReplicationConfig
 	SizeEstimationConcurrency int `validate:"gte=1"`
 }


### PR DESCRIPTION
By configuring your push or pull job with:

```yaml
conflict_resolution:
  initial_replication:
    replicate_all_snapshots: true
```

when a dataset is transferred for the first time, all snapshots on
that dataset will be transferred. This is disabled by default, and
only the most recent snapshot will be transferred.

Based on the names in https://github.com/zrepl/zrepl/issues/408#issuecomment-795329846
though the more complicated options suggested in that issue are
more Go than I know.

Closes #187 