### PR TITLE
Allow resuming from unencrypted raw/compressed sends

### DIFF
--- a/replication/logic/replication_logic.go
+++ b/replication/logic/replication_logic.go
@@ -396,9 +396,7 @@ func (fs *Filesystem) doPlanning(ctx context.Context) ([]*Step, error) {
 		switch fs.policy.EncryptedSend {
 		case True:
 			encryptionMatches = resumeToken.RawOK && resumeToken.CompressOK
-		case False:
-			encryptionMatches = !resumeToken.RawOK && !resumeToken.CompressOK
-		case DontCare:
+		case False, DontCare:
 			encryptionMatches = true
 		}
 

--- a/zfs/zfs.go
+++ b/zfs/zfs.go
@@ -799,18 +799,9 @@ func (a ZFSSendArgsUnvalidated) validateEncryptionFlagsCorrespondToResumeToken(c
 		return gen.fmt("resume token `toguid` != expected: %v != %v", t.ToGUID, a.To.GUID)
 	}
 
-	if a.Encrypted.B {
-		if !(t.RawOK && t.CompressOK) {
-			return ZFSSendArgsResumeTokenMismatchEncryptionNotSet.fmt(
-				"resume token must have `rawok` and `compressok` = true but got %v %v", t.RawOK, t.CompressOK)
-		}
-		// fallthrough
-	} else {
-		if t.RawOK || t.CompressOK {
-			return ZFSSendArgsResumeTokenMismatchEncryptionSet.fmt(
-				"resume token must not have `rawok` or `compressok` set but got %v %v", t.RawOK, t.CompressOK)
-		}
-		// fallthrough
+	if a.Encrypted.B && !(t.RawOK && t.CompressOK) {
+		return ZFSSendArgsResumeTokenMismatchEncryptionNotSet.fmt(
+			"resume token must have `rawok` and `compressok` = true but got %v %v", t.RawOK, t.CompressOK)
 	}
 
 	return nil


### PR DESCRIPTION
I don't think there's any reason this check that prevented this (originally introduced in #259) should exist, so this PR removes it. I have tested this myself and can confirm that removing this check and doing an unencrypted raw send doesn't break anything.