### PR TITLE
docs: Add quick-start guide for fan-out replication

### DIFF
--- a/config/samples/quickstart_fan_out_replication_source.yml
+++ b/config/samples/quickstart_fan_out_replication_source.yml
@@ -1,0 +1,66 @@
+jobs:
+# Separate job for snapshots and pruning
+- name: snapshots
+  type: snap
+  filesystems:
+    'pool0/dataset1': true
+    'pool0/dataset2': true
+  snapshotting:
+    type: periodic
+    prefix: zrepl_
+    interval: 10m
+  pruning:
+    keep:
+      # Keep non-zrepl snapshots
+      - type: regex
+        negate: true
+        regex: '^zrepl_'
+      # Time-based snapshot retention
+      - type: grid
+        grid: 1x1h(keep=all) | 24x1h | 30x1d | 12x30d
+        regex: '^zrepl_'
+
+# Source job for target B
+- name: target_b
+  type: source
+  serve:
+    type: tls
+    listen: :8888
+    ca: /etc/zrepl/b.example.com.crt
+    cert: /etc/zrepl/a.example.com.crt
+    key: /etc/zrepl/a.example.com.key
+    client_cns:
+      - b.example.com
+  filesystems:
+    'pool0/dataset1': true
+    'pool0/dataset2': true
+  send:
+    encrypted: true
+  # Snapshots are handled by the separate snap job
+  snapshotting:
+    type: manual
+
+# Source job for target C
+- name: target_c
+  type: source
+  serve:
+    type: tls
+    listen: :8889
+    ca: /etc/zrepl/c.example.com.crt
+    cert: /etc/zrepl/a.example.com.crt
+    key: /etc/zrepl/a.example.com.key
+    client_cns:
+      - c.example.com
+  filesystems:
+    'pool0/dataset1': true
+    'pool0/dataset2': true
+  send:
+    encrypted: true
+  # Snapshots are handled by the separate snap job
+  snapshotting:
+    type: manual
+
+# Source jobs for remaining targets. Each one should listen on a different port
+# and reference the correct certificate and client CN.
+# - name: target_c
+#   ...

--- a/config/samples/quickstart_fan_out_replication_target.yml
+++ b/config/samples/quickstart_fan_out_replication_target.yml
@@ -1,0 +1,30 @@
+jobs:
+# Pull from source server A
+- name: source_a
+  type: pull
+  connect:
+    type: tls
+    # Use the correct port for this specific client (eg. B is 8888, C is 8889, etc.)
+    address: a.example.com:8888
+    ca: /etc/zrepl/a.example.com.crt
+    # Use the correct key pair for this specific client
+    cert: /etc/zrepl/b.example.com.crt
+    key: /etc/zrepl/b.example.com.key
+    server_cn: a.example.com
+  root_fs: pool0/backup
+  interval: 10m
+  pruning:
+    keep_sender:
+      # Source does the pruning in its snap job
+      - type: regex
+        regex: '.*'
+    # Receiver-side pruning can be configured as desired on each target server
+    keep_receiver:
+      # Keep non-zrepl snapshots
+      - type: regex
+        negate: true
+        regex: '^zrepl_'
+      # Time-based snapshot retention
+      - type: grid
+        grid: 1x1h(keep=all) | 24x1h | 30x1d | 12x30d
+        regex: '^zrepl_'

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -33,6 +33,7 @@ Keep the :ref:`full config documentation <configuration_toc>` handy if a config 
 
    quickstart/continuous_server_backup
    quickstart/backup_to_external_disk
+   quickstart/fan_out_replication
 
 Use ``zrepl configcheck`` to validate your configuration.
 No output indicates that everything is fine.

--- a/docs/quickstart/fan_out_replication.rst
+++ b/docs/quickstart/fan_out_replication.rst
@@ -1,0 +1,93 @@
+.. include:: ../global.rst.inc
+
+.. _quickstart-fan-out-replication:
+
+Fan-out replication
+===================
+
+This quick-start example demonstrates how to implement a fan-out replication setup where datasets on a server (A) are replicated to multiple targets (B, C, etc.).
+
+This example uses multiple ``source`` jobs on server A and ``pull`` jobs on the target servers.
+
+.. WARNING::
+
+   Before implementing this setup, please see the caveats listed in the :ref:`fan-out replication configuration overview <fan-out-replication>`.
+
+Overview
+--------
+
+On the source server (A), there should be:
+
+* A ``snap`` job
+
+  * Creates the snapshots
+  * Handles the pruning of snapshots
+
+* A ``source`` job for target B
+
+  * Accepts connections from server B and B only
+
+* Further ``source`` jobs for each additional target (C, D, etc.)
+
+  * Listens on a unique port
+  * Only accepts connections from the specific target
+
+On each target server, there should be:
+
+* A ``pull`` job that connects to the corresponding ``source`` job on A
+
+  * ``prune_sender`` should keep all snapshots since A's ``snap`` job handles the pruning
+  * ``prune_receiver`` can be configured as appropriate on each target server
+
+Generate TLS Certificates
+-------------------------
+
+Mutual TLS via the :ref:`TLS client authentication transport <transport-tcp+tlsclientauth>` can be used to secure the connections between the servers. In this example, a self-signed certificate is created for each server without setting up a CA.
+
+.. code-block:: bash
+
+    source=a.example.com
+    targets=(
+        b.example.com
+        c.example.com
+        # ...
+    )
+
+    for server in "${source}" "${targets[@]}"; do
+        openssl req -x509 -sha256 -nodes \
+            -newkey rsa:4096 \
+            -days 365 \
+            -keyout "${server}.key" \
+            -out "${server}.crt" \
+            -addext "subjectAltName = DNS:${server}" \
+            -subj "/CN=${server}"
+    done
+
+    # Distribute each host's keypair
+    for server in "${source}" "${targets[@]}"; do
+        ssh root@"${server}" mkdir /etc/zrepl
+        scp "${server}".{crt,key} root@"${server}":/etc/zrepl/
+    done
+
+    # Distribute target certificates to the source
+    scp "${targets[@]/%/.crt}" root@"${source}":/etc/zrepl/
+
+    # Distribute source certificate to the targets
+    for server in "${targets[@]}"; do
+        scp "${source}.crt" root@"${server}":/etc/zrepl/
+    done
+
+Configure source server A
+-------------------------
+
+.. literalinclude:: ../../config/samples/quickstart_fan_out_replication_source.yml
+
+Configure each target server
+----------------------------
+
+.. literalinclude:: ../../config/samples/quickstart_fan_out_replication_target.yml
+
+Go Back To Quickstart Guide
+---------------------------
+
+:ref:`Click here <quickstart-apply-config>` to go back to the quickstart guide.


### PR DESCRIPTION
This PR adds adds a quick-start guide for fan-out replication using `source`/`pull` jobs. The `More Than 2 Machines` section in the configuration overview page has also been updated to indicate that this type of setup is possible.

See: #551