### PR TITLE
status: fix over-counted step when status != stepping

### DIFF
--- a/client/status/viewmodel/render.go
+++ b/client/status/viewmodel/render.go
@@ -228,8 +228,16 @@ func printFilesystemStatus(t *stringbuilder.B, rep *report.FilesystemReport, max
 	}
 
 	userVisisbleCurrentStep, userVisibleTotalSteps := rep.CurrentStep, len(rep.Steps)
-	if len(rep.Steps) > 0 {
-		userVisisbleCurrentStep = rep.CurrentStep + 1 // CurrentStep is an index that starts at 0
+	// `.CurrentStep` is == len(rep.Steps) if all steps are done.
+	// Until then, it's an index into .Steps that starts at 0.
+	// For the user, we want it to start at 1.
+	if rep.CurrentStep >= len(rep.Steps) {
+		// rep.CurrentStep is what we want to show.
+		// We check for >= and not == for robustness.
+	} else {
+		// We're not done yet, so, make step count start at 1
+		// (The `.State` is included in the output, indicating we're not done yet)
+		userVisisbleCurrentStep = rep.CurrentStep + 1
 	}
 	status := fmt.Sprintf("%s (step %d/%d, %s/%s)%s",
 		strings.ToUpper(string(rep.State)),


### PR DESCRIPTION
This is a fixup of

  commit https://github.com/zrepl/zrepl/commit/b00b61e9677209790ec9a018036e24b8ae336d52
  Author: Christian Schwarz <me@cschwarz.com>
  Date:   Sun Nov 21 15:15:23 2021 +0100

      status: user-visible replication step number should start at 1

fixes https://github.com/zrepl/zrepl/issues/589
refs https://github.com/zrepl/zrepl/issues/538


---


@gdevenyi please test this fix.