### PR TITLE
Allow setting destroy max batch size

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,7 @@ Developers should consult the git commit log or GitHub issue tracker.
 
 * `Feature Wishlist on GitHub <https://github.com/zrepl/zrepl/discussions/547>`_
 
+* |feature| Add ``ZREPL_DESTROY_MAX_BATCH_SIZE`` env var (default 0=unlimited).
 * |break| |feature| convert Prometheus metric ``zrepl_version_daemon`` to ``zrepl_start_time`` metric
 
   * The metric still reports the zrepl version in a label.
@@ -275,7 +276,7 @@ Changes
 * |feature| Proper timeout handling for the :ref:`SSH transport <transport-ssh+stdinserver>`
 
   * |break| Requires Go 1.11 or later.
-  
+
 * |break| |break_config|: mappings are no longer supported
 
   * Receiving sides (``pull`` and ``sink`` job) specify a single ``root_fs``.

--- a/zfs/versions_destroy.go
+++ b/zfs/versions_destroy.go
@@ -115,9 +115,10 @@ func buildBatches(reqs []*DestroySnapOp) [][]*DestroySnapOp {
 	// group by fs
 	var perFS [][]*DestroySnapOp
 	consumed := 0
+	maxBatchSize := envconst.Int("ZREPL_DESTROY_MAX_BATCH_SIZE", 0)
 	for consumed < len(sorted) {
 		batchConsumedUntil := consumed
-		for ; batchConsumedUntil < len(sorted) && sorted[batchConsumedUntil].Filesystem == sorted[consumed].Filesystem; batchConsumedUntil++ {
+		for ; batchConsumedUntil < len(sorted) && (maxBatchSize < 1 || batchConsumedUntil-consumed < maxBatchSize) && sorted[batchConsumedUntil].Filesystem == sorted[consumed].Filesystem; batchConsumedUntil++ {
 		}
 		perFS = append(perFS, sorted[consumed:batchConsumedUntil])
 		consumed = batchConsumedUntil


### PR DESCRIPTION
Add env var `ZREPL_DESTROY_MAX_BATCH_SIZE` to allow changing the max batch size for batch destroys. The default is set to 200.

Resolves #508 