### PR TITLE
Use $(MAKE) instead of make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -333,12 +333,12 @@ $(ARTIFACTDIR)/go_env.txt:
 
 docs: $(ARTIFACTDIR)/docs
 	# https://www.sphinx-doc.org/en/master/man/sphinx-build.html
-	make -C docs \
+	$(MAKE) -C docs \
 		html \
 		BUILDDIR=../artifacts/docs \
 		SPHINXOPTS="-W --keep-going -n"
 
 docs-clean:
-	make -C docs \
+	$(MAKE) -C docs \
 		clean \
 		BUILDDIR=../artifacts/docs


### PR DESCRIPTION
Building on FreeBSD on should execute `gmake` not `make`, fixing it by using $(MAKE).