### PR TITLE
Filter bookmarks when searching filesystem versions.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -29,6 +29,8 @@ Developers should consult the git commit log or GitHub issue tracker.
     The Grafana dashboard in :repomasterlink:`dist/grafana` has been updated.
 
 * |bugfix| transient zrepl status error: ``Post "http://unix/status": EOF``
+* |bugfix| don't treat receive-side bookmarks as a replication conflict.
+  This facilitates chaining of replication jobs. See :issue:`490`.
 
 0.5
 ---

--- a/replication/logic/diff/diff_test.go
+++ b/replication/logic/diff/diff_test.go
@@ -152,4 +152,18 @@ func TestIncrementalPath_BookmarkSupport(t *testing.T) {
 		assert.Equal(t, l("@a,1", "@b,2"), path)
 	})
 
+	// test that receive-side bookmarks younger than the most recent common ancestor do not cause a conflict
+	doTest(l("@a,1", "#b,2"), l("@a,1", "@c,3"), func(path []*FilesystemVersion, conflict error) {
+		assert.NoError(t, conflict)
+		require.Len(t, path, 2)
+		assert.Equal(t, l("@a,1")[0], path[0])
+		assert.Equal(t, l("@c,3")[0], path[1])
+	})
+	doTest(l("#a,1"), l("@a,1", "@b,2"), func(path []*FilesystemVersion, conflict error) {
+		assert.Nil(t, path)
+		ca, ok := conflict.(*ConflictNoCommonAncestor)
+		require.True(t, ok)
+		assert.Equal(t, l(), ca.SortedReceiverVersions, "See comment in IncrementalPath() on why we don't include the boomkmark here")
+	})
+
 }


### PR DESCRIPTION
Fixes #490

This is an old bug that I found and have been using this fix since. I've updated it to the newest version and seems to be working fine. @kpfleming please test it if you have the resources for it.

@problame please review.

