### PR TITLE
feat: configurable timestamp format

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -228,11 +228,11 @@ type SnapshottingEnum struct {
 }
 
 type SnapshottingPeriodic struct {
-	Type               string        `yaml:"type"`
-	Prefix             string        `yaml:"prefix"`
-	Interval           time.Duration `yaml:"interval,positive"`
-	Hooks              HookList      `yaml:"hooks,optional"`
-	UtcTimestampFormat string        `yaml:"utc_timestamp_format,optional"`
+	Type            string        `yaml:"type"`
+	Prefix          string        `yaml:"prefix"`
+	Interval        time.Duration `yaml:"interval,positive"`
+	Hooks           HookList      `yaml:"hooks,optional"`
+	TimestampFormat string        `yaml:"timestamp_format,optional,default=dense"`
 }
 
 type CronSpec struct {
@@ -261,11 +261,11 @@ func (s *CronSpec) UnmarshalYAML(unmarshal func(v interface{}, not_strict bool) 
 }
 
 type SnapshottingCron struct {
-	Type               string   `yaml:"type"`
-	Prefix             string   `yaml:"prefix"`
-	Cron               CronSpec `yaml:"cron"`
-	Hooks              HookList `yaml:"hooks,optional"`
-	UtcTimestampFormat string   `yaml:"utc_timestamp_format,optional"`
+	Type            string   `yaml:"type"`
+	Prefix          string   `yaml:"prefix"`
+	Cron            CronSpec `yaml:"cron"`
+	Hooks           HookList `yaml:"hooks,optional"`
+	TimestampFormat string   `yaml:"timestamp_format,optional,default=dense"`
 }
 
 type SnapshottingManual struct {

--- a/config/config.go
+++ b/config/config.go
@@ -228,10 +228,11 @@ type SnapshottingEnum struct {
 }
 
 type SnapshottingPeriodic struct {
-	Type     string        `yaml:"type"`
-	Prefix   string        `yaml:"prefix"`
-	Interval time.Duration `yaml:"interval,positive"`
-	Hooks    HookList      `yaml:"hooks,optional"`
+	Type               string        `yaml:"type"`
+	Prefix             string        `yaml:"prefix"`
+	Interval           time.Duration `yaml:"interval,positive"`
+	Hooks              HookList      `yaml:"hooks,optional"`
+	UtcTimestampFormat string        `yaml:"utc_timestamp_format,optional"`
 }
 
 type CronSpec struct {
@@ -260,10 +261,11 @@ func (s *CronSpec) UnmarshalYAML(unmarshal func(v interface{}, not_strict bool) 
 }
 
 type SnapshottingCron struct {
-	Type   string   `yaml:"type"`
-	Prefix string   `yaml:"prefix"`
-	Cron   CronSpec `yaml:"cron"`
-	Hooks  HookList `yaml:"hooks,optional"`
+	Type               string   `yaml:"type"`
+	Prefix             string   `yaml:"prefix"`
+	Cron               CronSpec `yaml:"cron"`
+	Hooks              HookList `yaml:"hooks,optional"`
+	UtcTimestampFormat string   `yaml:"utc_timestamp_format,optional"`
 }
 
 type SnapshottingManual struct {

--- a/config/config_snapshotting_test.go
+++ b/config/config_snapshotting_test.go
@@ -35,6 +35,7 @@ jobs:
   snapshotting:
     type: periodic
     prefix: zrepl_
+    utc_timestamp_format: dense
     interval: 10m
 `
 
@@ -76,6 +77,7 @@ jobs:
 		assert.Equal(t, "periodic", snp.Type)
 		assert.Equal(t, 10*time.Minute, snp.Interval)
 		assert.Equal(t, "zrepl_", snp.Prefix)
+		assert.Equal(t, "dense", snp.UtcTimestampFormat)
 	})
 
 	t.Run("hooks", func(t *testing.T) {

--- a/config/config_snapshotting_test.go
+++ b/config/config_snapshotting_test.go
@@ -35,7 +35,7 @@ jobs:
   snapshotting:
     type: periodic
     prefix: zrepl_
-    utc_timestamp_format: dense
+    timestamp_format: dense
     interval: 10m
 `
 
@@ -77,7 +77,7 @@ jobs:
 		assert.Equal(t, "periodic", snp.Type)
 		assert.Equal(t, 10*time.Minute, snp.Interval)
 		assert.Equal(t, "zrepl_", snp.Prefix)
-		assert.Equal(t, "dense", snp.UtcTimestampFormat)
+		assert.Equal(t, "dense", snp.TimestampFormat)
 	})
 
 	t.Run("hooks", func(t *testing.T) {

--- a/config/config_snapshotting_test.go
+++ b/config/config_snapshotting_test.go
@@ -38,6 +38,13 @@ jobs:
     timestamp_format: dense
     interval: 10m
 `
+	cron := `
+  snapshotting:
+    type: cron
+    prefix: zrepl_
+    timestamp_format: human
+    cron: "10 * * * *"
+`
 
 	hooks := `
   snapshotting:
@@ -80,6 +87,14 @@ jobs:
 		assert.Equal(t, "dense", snp.TimestampFormat)
 	})
 
+	t.Run("cron", func(t *testing.T) {
+		c = testValidConfig(t, fillSnapshotting(cron))
+		snp := c.Jobs[0].Ret.(*PushJob).Snapshotting.Ret.(*SnapshottingCron)
+		assert.Equal(t, "cron", snp.Type)
+		assert.Equal(t, "zrepl_", snp.Prefix)
+		assert.Equal(t, "human", snp.TimestampFormat)
+	})
+
 	t.Run("hooks", func(t *testing.T) {
 		c = testValidConfig(t, fillSnapshotting(hooks))
 		hs := c.Jobs[0].Ret.(*PushJob).Snapshotting.Ret.(*SnapshottingPeriodic).Hooks
@@ -89,4 +104,58 @@ jobs:
 		assert.Equal(t, hs[3].Ret.(*HookMySQLLockTables).Filesystems["tank/mysql"], true)
 	})
 
+}
+
+func TestSnapshottingTimestampDefaults(t *testing.T) {
+	tmpl := `
+jobs:
+- name: foo
+  type: push
+  connect:
+    type: local
+    listener_name: foo
+    client_identity: bar
+  filesystems: {"<": true}
+  %s
+  pruning:
+    keep_sender:
+    - type: last_n
+      count: 10
+    keep_receiver:
+    - type: last_n
+      count: 10
+`
+
+	periodic := `
+  snapshotting:
+    type: periodic
+    prefix: zrepl_
+    interval: 10m
+`
+	cron := `
+  snapshotting:
+    type: cron
+    prefix: zrepl_
+    cron: "10 * * * *"
+`
+
+	fillSnapshotting := func(s string) string { return fmt.Sprintf(tmpl, s) }
+	var c *Config
+
+	t.Run("periodic", func(t *testing.T) {
+		c = testValidConfig(t, fillSnapshotting(periodic))
+		snp := c.Jobs[0].Ret.(*PushJob).Snapshotting.Ret.(*SnapshottingPeriodic)
+		assert.Equal(t, "periodic", snp.Type)
+		assert.Equal(t, 10*time.Minute, snp.Interval)
+		assert.Equal(t, "zrepl_", snp.Prefix)
+		assert.Equal(t, "dense", snp.TimestampFormat) // default was set correctly
+	})
+
+	t.Run("cron", func(t *testing.T) {
+		c = testValidConfig(t, fillSnapshotting(cron))
+		snp := c.Jobs[0].Ret.(*PushJob).Snapshotting.Ret.(*SnapshottingCron)
+		assert.Equal(t, "cron", snp.Type)
+		assert.Equal(t, "zrepl_", snp.Prefix)
+		assert.Equal(t, "dense", snp.TimestampFormat) // default was set correctly
+	})
 }

--- a/daemon/snapper/cron.go
+++ b/daemon/snapper/cron.go
@@ -20,8 +20,9 @@ func cronFromConfig(fsf zfs.DatasetFilter, in config.SnapshottingCron) (*Cron, e
 		return nil, errors.Wrap(err, "hook config error")
 	}
 	planArgs := planArgs{
-		prefix: in.Prefix,
-		hooks:  hooksList,
+		prefix:          in.Prefix,
+		timestampFormat: in.UtcTimestampFormat,
+		hooks:           hooksList,
 	}
 	return &Cron{config: in, fsf: fsf, planArgs: planArgs}, nil
 }

--- a/daemon/snapper/cron.go
+++ b/daemon/snapper/cron.go
@@ -21,7 +21,7 @@ func cronFromConfig(fsf zfs.DatasetFilter, in config.SnapshottingCron) (*Cron, e
 	}
 	planArgs := planArgs{
 		prefix:          in.Prefix,
-		timestampFormat: in.UtcTimestampFormat,
+		timestampFormat: in.TimestampFormat,
 		hooks:           hooksList,
 	}
 	return &Cron{config: in, fsf: fsf, planArgs: planArgs}, nil

--- a/daemon/snapper/impl.go
+++ b/daemon/snapper/impl.go
@@ -63,7 +63,7 @@ type snapProgress struct {
 func (plan *plan) formatNow(format string) string {
 	now := time.Now().UTC()
 	switch strings.ToLower(format) {
-	case "", "dense":
+	case "dense":
 		format = "20060102_150405_000"
 	case "human":
 		format = "2006-01-02_15:04:05"

--- a/daemon/snapper/periodic.go
+++ b/daemon/snapper/periodic.go
@@ -36,7 +36,7 @@ func periodicFromConfig(g *config.Global, fsf zfs.DatasetFilter, in *config.Snap
 		fsf:      fsf,
 		planArgs: planArgs{
 			prefix:          in.Prefix,
-			timestampFormat: in.UtcTimestampFormat,
+			timestampFormat: in.TimestampFormat,
 			hooks:           hookList,
 		},
 		// ctx and log is set in Run()

--- a/daemon/snapper/periodic.go
+++ b/daemon/snapper/periodic.go
@@ -35,8 +35,9 @@ func periodicFromConfig(g *config.Global, fsf zfs.DatasetFilter, in *config.Snap
 		interval: in.Interval,
 		fsf:      fsf,
 		planArgs: planArgs{
-			prefix: in.Prefix,
-			hooks:  hookList,
+			prefix:          in.Prefix,
+			timestampFormat: in.UtcTimestampFormat,
+			hooks:           hookList,
 		},
 		// ctx and log is set in Run()
 	}

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,7 +22,7 @@ Developers should consult the git commit log or GitHub issue tracker.
 * `Feature Wishlist on GitHub <https://github.com/zrepl/zrepl/discussions/547>`_
 
 * |feature| :ref:`Schedule-based snapshotting<job-snapshotting--cron>` using ``cron`` syntax instead of an interval.
-* |feature| Configurable timestamp format for snapshot names via :ref:`utc_timestamp_format<job-snapshotting-timestamp_format>`.
+* |feature| Configurable timestamp format for snapshot names via :ref:`timestamp_format<job-snapshotting-timestamp_format>`.
 * |feature| Add ``ZREPL_DESTROY_MAX_BATCH_SIZE`` env var (default 0=unlimited).
 * |bugfix| Fix resuming from interrupted replications that use ``send.raw`` on unencrypted datasets.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,7 @@ Developers should consult the git commit log or GitHub issue tracker.
 * `Feature Wishlist on GitHub <https://github.com/zrepl/zrepl/discussions/547>`_
 
 * |feature| :ref:`Schedule-based snapshotting<job-snapshotting--cron>` using ``cron`` syntax instead of an interval.
+* |feature| Configurable timestamp format for snapshot names via :ref:`utc_timestamp_format<job-snapshotting-timestamp_format>`.
 * |feature| Add ``ZREPL_DESTROY_MAX_BATCH_SIZE`` env var (default 0=unlimited).
 * |bugfix| Fix resuming from interrupted replications that use ``send.raw`` on unencrypted datasets.
 

--- a/docs/configuration/snapshotting.rst
+++ b/docs/configuration/snapshotting.rst
@@ -64,7 +64,7 @@ The ``periodic`` and ``cron`` snapshotting types share some common options and b
        interval: 10m
        # Timestamp format that is used as snapshot suffix.
        # Can be any of "dense" (default), "human", "iso-8601", "unix-seconds" or a custom Go time format (see https://go.dev/src/time/format.go)
-       utc_timestamp_format: dense
+       timestamp_format: dense
        hooks: ...
     pruning: ...
 
@@ -96,7 +96,7 @@ The snapshotter uses the ``prefix`` to identify which snapshots it created.
        cron: "0 3 * * *"
        # Timestamp format that is used as snapshot suffix.
        # Can be any of "dense" (default), "human", "iso-8601", "unix-seconds" or a custom Go time format (see https://go.dev/src/time/format.go)
-       utc_timestamp_format: dense
+       timestamp_format: dense
      pruning: ...
 
 In ``cron`` mode, the snapshotter takes snaphots at fixed points in time.
@@ -106,11 +106,11 @@ An optional field for "seconds" is supported to take snapshots at sub-minute fre
 
 .. _job-snapshotting-timestamp_format:
 
-``utc_timestamp_format`` Timestamp Format
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Timestamp Format
+~~~~~~~~~~~~~~~~
 
 The ``cron`` and ``periodic`` snapshotter support configuring a custom timestamp format that is used as suffix for the snapshot name.
-It can be used by setting ``utc_timestamp_format`` to any of the following values:
+It can be used by setting ``timestamp_format`` to any of the following values:
 
 * ``dense`` (default) looks like ``20060102_150405_000``
 * ``human`` looks like ``2006-01-02_15:04:05``

--- a/docs/configuration/snapshotting.rst
+++ b/docs/configuration/snapshotting.rst
@@ -62,6 +62,9 @@ The ``periodic`` and ``cron`` snapshotting types share some common options and b
        type: periodic
        prefix: zrepl_
        interval: 10m
+       # Timestamp format that is used as snapshot suffix.
+       # Can be any of "dense" (default), "human", "iso-8601", "unix-seconds" or a custom Go time format (see https://go.dev/src/time/format.go)
+       utc_timestamp_format: dense
        hooks: ...
     pruning: ...
 
@@ -91,12 +94,30 @@ The snapshotter uses the ``prefix`` to identify which snapshots it created.
        # (second, optional) minute hour day-of-month month day-of-week
        # This example takes snapshots daily at 3:00.
        cron: "0 3 * * *"
+       # Timestamp format that is used as snapshot suffix.
+       # Can be any of "dense" (default), "human", "iso-8601", "unix-seconds" or a custom Go time format (see https://go.dev/src/time/format.go)
+       utc_timestamp_format: dense
      pruning: ...
 
 In ``cron`` mode, the snapshotter takes snaphots at fixed points in time.
 See https://en.wikipedia.org/wiki/Cron for details on the syntax.
 zrepl uses the ``the github.com/robfig/cron/v3`` Go package for parsing.
 An optional field for "seconds" is supported to take snapshots at sub-minute frequencies.
+
+.. _job-snapshotting-timestamp_format:
+
+``utc_timestamp_format`` Timestamp Format
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``cron`` and ``periodic`` snapshotter support configuring a custom timestamp format that is used as suffix for the snapshot name.
+It can be used by setting ``utc_timestamp_format`` to any of the following values:
+
+* ``dense`` (default) looks like ``20060102_150405_000``
+* ``human`` looks like ``2006-01-02_15:04:05``
+* ``iso-8601`` looks like ``2006-01-02T15:04:05.000Z``
+* ``unix-seconds`` looks like ``1136214245``
+* Any custom Go time format accepted by `time.Time#Format <https://go.dev/src/time/format.go>`_.
+
 
 ``manual`` Snapshotting
 -----------------------


### PR DESCRIPTION
Hi @problame,
this is a continuation of PR #466 where you proposed a new config option to change the timestamp format that is used in the snapshot names.  
The new option is called `utc_timestamp_format` and can be used with the `cron` and `periodic` job types. It defaults to the old timestamp format (which is now called `dense`) so existing installations should not break.  
People that want to change it can now choose between `dense`, `human`, `iso-8601`, `unix-seconds` or any custom format that is accepted by Go's `time.Time#Format`.

I also tried to add docs but I am not sure how they look rendered, since I did not want to setup sphinx. Maybe you can take a look and ensure they look nice?

Closes #465 