### PR TITLE
remove unused JobDebugSettings along with docs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -65,7 +65,6 @@ type ActiveJob struct {
 	Name               string                `yaml:"name"`
 	Connect            ConnectEnum           `yaml:"connect"`
 	Pruning            PruningSenderReceiver `yaml:"pruning"`
-	Debug              JobDebugSettings      `yaml:"debug,optional"`
 	Replication        *Replication          `yaml:"replication,optional,fromdefaults"`
 	ConflictResolution *ConflictResolution   `yaml:"conflict_resolution,optional,fromdefaults"`
 }
@@ -75,17 +74,15 @@ type ConflictResolution struct {
 }
 
 type PassiveJob struct {
-	Type  string           `yaml:"type"`
-	Name  string           `yaml:"name"`
-	Serve ServeEnum        `yaml:"serve"`
-	Debug JobDebugSettings `yaml:"debug,optional"`
+	Type  string    `yaml:"type"`
+	Name  string    `yaml:"name"`
+	Serve ServeEnum `yaml:"serve"`
 }
 
 type SnapJob struct {
 	Type         string            `yaml:"type"`
 	Name         string            `yaml:"name"`
 	Pruning      PruningLocal      `yaml:"pruning"`
-	Debug        JobDebugSettings  `yaml:"debug,optional"`
 	Snapshotting SnapshottingEnum  `yaml:"snapshotting"`
 	Filesystems  FilesystemsFilter `yaml:"filesystems"`
 }
@@ -478,14 +475,6 @@ type GlobalServe struct {
 
 type GlobalStdinServer struct {
 	SockDir string `yaml:"sockdir,default=/var/run/zrepl/stdinserver"`
-}
-
-type JobDebugSettings struct {
-	Conn *struct {
-		ReadDump  string `yaml:"read_dump"`
-		WriteDump string `yaml:"write_dump"`
-	} `yaml:"conn,optional"`
-	RPCLog bool `yaml:"rpc_log,optional,default=false"`
 }
 
 type HookList []HookEnum

--- a/docs/configuration/misc.rst
+++ b/docs/configuration/misc.rst
@@ -44,27 +44,3 @@ Interval & duration fields in job definitions, pruning configurations, etc. must
 
     var durationStringRegex *regexp.Regexp = regexp.MustCompile(`^\s*(\d+)\s*(s|m|h|d|w)\s*$`)
     // s = second, m = minute, h = hour, d = day, w = week (7 days)
-
-Super-Verbose Job Debugging
----------------------------
-
-You have probably landed here because you opened an issue on GitHub and some developer told you to do this...
-So just read the annotated comments ;)
-
-::
-
-    job:
-    - name: ...
-      ...
-     # JOB DEBUGGING OPTIONS
-      # should be equal for all job types, but each job implements the debugging itself
-      debug:
-        conn: # debug the io.ReadWriteCloser connection
-          read_dump: /tmp/connlog_read   # dump results of Read() invocations to this file
-          write_dump: /tmp/connlog_write # dump results of Write() invocations to this file
-        rpc: # debug the RPC protocol implementation
-          log: true # log output from rpc layer to the job log
-
-.. ATTENTION::
-
-    Connection dumps will almost certainly contain your or other's private data. Do not share it in a bug report.


### PR DESCRIPTION
For this kind of debugging, we switched to env vars a while ago.
For example, ZREPL_RPC_DEBUG.

I don't think we have a substitute for the RPCLog stuff.
However, NetConnLogger is still in the codebase.

obsoletes https://github.com/zrepl/zrepl/pull/661