### PR TITLE
Fix issue #165. zrepl status: hide progress bar once all filesystems reach terminal state

### DIFF
--- a/client/status/viewmodel/render.go
+++ b/client/status/viewmodel/render.go
@@ -374,13 +374,15 @@ func renderReplicationReport(t *stringbuilder.B, rep *report.Report, history *by
 			eta = time.Duration((float64(expected)-float64(replicated))/float64(rate)) * time.Second
 		}
 
-		t.Write("Progress: ")
-		t.DrawBar(50, replicated, expected, changeCount)
-		t.Write(fmt.Sprintf(" %s / %s @ %s/s", ByteCountBinaryUint(replicated), ByteCountBinaryUint(expected), ByteCountBinary(rate)))
-		if eta != 0 {
-			t.Write(fmt.Sprintf(" (%s remaining)", humanizeDuration(eta)))
+		if latest.State != report.AttemptDone {
+			t.Write("Progress: ")
+			t.DrawBar(50, replicated, expected, changeCount)
+			t.Write(fmt.Sprintf(" %s / %s @ %s/s", ByteCountBinaryUint(replicated), ByteCountBinaryUint(expected), ByteCountBinary(rate)))
+			if eta != 0 {
+				t.Write(fmt.Sprintf(" (%s remaining)", humanizeDuration(eta)))
+			}
+			t.Newline()
 		}
-		t.Newline()
 		if containsInvalidSizeEstimates {
 			t.Write("NOTE: not all steps could be size-estimated, total estimate is likely imprecise!")
 			t.Newline()
@@ -493,15 +495,17 @@ func renderPrunerReport(t *stringbuilder.B, r *pruner.Report, fsfilter FilterFun
 	}
 
 	// global progress bar
-	progress := int(math.Round(80 * float64(completedDestroyCount) / float64(totalDestroyCount)))
-	t.Write("Progress: ")
-	t.Write("[")
-	t.Write(stringbuilder.Times("=", progress))
-	t.Write(">")
-	t.Write(stringbuilder.Times("-", 80-progress))
-	t.Write("]")
-	t.Printf(" %d/%d snapshots", completedDestroyCount, totalDestroyCount)
-	t.Newline()
+	if state != pruner.Done {
+		progress := int(math.Round(80 * float64(completedDestroyCount) / float64(totalDestroyCount)))
+		t.Write("Progress: ")
+		t.Write("[")
+		t.Write(stringbuilder.Times("=", progress))
+		t.Write(">")
+		t.Write(stringbuilder.Times("-", 80-progress))
+		t.Write("]")
+		t.Printf(" %d/%d snapshots", completedDestroyCount, totalDestroyCount)
+		t.Newline()
+	}
 
 	sort.SliceStable(all, func(i, j int) bool {
 		return strings.Compare(all[i].Filesystem, all[j].Filesystem) == -1

--- a/client/status/viewmodel/render.go
+++ b/client/status/viewmodel/render.go
@@ -496,8 +496,13 @@ func renderPrunerReport(t *stringbuilder.B, r *pruner.Report, fsfilter FilterFun
 
 	// global progress bar
 	if !state.IsTerminal() {
+		progress := int(math.Round(80 * float64(completedDestroyCount) / float64(totalDestroyCount)))
 		t.Write("Progress: ")
-		t.DrawBar(80, uint64(completedDestroyCount), uint64(totalDestroyCount), 1)
+		t.Write("[")
+		t.Write(stringbuilder.Times("=", progress))
+		t.Write(">")
+		t.Write(stringbuilder.Times("-", 80-progress))
+		t.Write("]")
 		t.Printf(" %d/%d snapshots", completedDestroyCount, totalDestroyCount)
 		t.Newline()
 	}

--- a/client/status/viewmodel/render.go
+++ b/client/status/viewmodel/render.go
@@ -374,7 +374,7 @@ func renderReplicationReport(t *stringbuilder.B, rep *report.Report, history *by
 			eta = time.Duration((float64(expected)-float64(replicated))/float64(rate)) * time.Second
 		}
 
-		if latest.State != report.AttemptDone {
+		if !latest.State.IsTerminal() {
 			t.Write("Progress: ")
 			t.DrawBar(50, replicated, expected, changeCount)
 			t.Write(fmt.Sprintf(" %s / %s @ %s/s", ByteCountBinaryUint(replicated), ByteCountBinaryUint(expected), ByteCountBinary(rate)))
@@ -495,14 +495,9 @@ func renderPrunerReport(t *stringbuilder.B, r *pruner.Report, fsfilter FilterFun
 	}
 
 	// global progress bar
-	if state != pruner.Done {
-		progress := int(math.Round(80 * float64(completedDestroyCount) / float64(totalDestroyCount)))
+	if !state.IsTerminal() {
 		t.Write("Progress: ")
-		t.Write("[")
-		t.Write(stringbuilder.Times("=", progress))
-		t.Write(">")
-		t.Write(stringbuilder.Times("-", 80-progress))
-		t.Write("]")
+		t.DrawBar(80, uint64(completedDestroyCount), uint64(totalDestroyCount), 1)
 		t.Printf(" %d/%d snapshots", completedDestroyCount, totalDestroyCount)
 		t.Newline()
 	}

--- a/daemon/pruner/pruner.go
+++ b/daemon/pruner/pruner.go
@@ -199,6 +199,16 @@ const (
 	Done
 )
 
+// Returns true in case the State is a terminal state(PlanErr, ExecErr, Done)
+func (s State) IsTerminal() bool {
+	switch s {
+	case PlanErr, ExecErr, Done:
+		return true
+	default:
+		return false
+	}
+}
+
 type updater func(func(*Pruner))
 
 func (p *Pruner) Prune() {

--- a/replication/report/replication_report.go
+++ b/replication/report/replication_report.go
@@ -192,3 +192,14 @@ func (r *Report) GetFailedFilesystemsCountInLatestAttempt() int {
 		return 0
 	}
 }
+
+// Returns true in case the AttemptState is a terminal
+// state(AttemptPlanningError, AttemptFanOutError, AttemptDone)
+func (a AttemptState) IsTerminal() bool {
+	switch a {
+	case AttemptPlanningError, AttemptFanOutError, AttemptDone:
+		return true
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
Hide the progress bar once all filesystems reach terminal state on pruner.

Before:
![image](https://user-images.githubusercontent.com/289289/214378526-5de306eb-0721-4616-b6bc-9c75231a004c.png)

After:
![image](https://user-images.githubusercontent.com/289289/214378546-08cd0edc-c924-4ba1-ace3-7650b1696fa8.png)

