### PR TITLE
docs/jobs: add replication- conflict_resolution-options to active jobs

### DIFF
--- a/docs/configuration/conflict_resolution.rst
+++ b/docs/configuration/conflict_resolution.rst
@@ -1,5 +1,6 @@
 .. include:: ../global.rst.inc
 
+.. _conflict_resolution-options:
 
 Conflict Resolution Options
 ===========================

--- a/docs/configuration/jobs.rst
+++ b/docs/configuration/jobs.rst
@@ -30,6 +30,10 @@ Job Type ``push``
       - |snapshotting-spec|
     * - ``pruning``
       - |pruning-spec|
+    * - ``replication``
+      - |replication-options|
+    * - ``conflict_resolution``
+      - |conflict-resolution-options|
 
 Example config: :sampleconf:`/push.yml`
 
@@ -81,6 +85,10 @@ Job Type ``pull``
         | ``manual`` disables periodic pulling, replication then only happens on :ref:`wakeup <cli-signal-wakeup>`.
     * - ``pruning``
       - |pruning-spec|
+    * - ``replication``
+      - |replication-options|
+    * - ``conflict_resolution``
+      - |conflict-resolution-options|
 
 Example config: :sampleconf:`/pull.yml`
 

--- a/docs/configuration/replication.rst
+++ b/docs/configuration/replication.rst
@@ -1,5 +1,6 @@
 .. include:: ../global.rst.inc
 
+.. _replication-options:
 
 Replication Options
 ===================

--- a/docs/global.rst.inc
+++ b/docs/global.rst.inc
@@ -26,6 +26,8 @@
 .. |connect-transport| replace:: :ref:`connect specification<transport>`
 .. |send-options| replace:: :ref:`send options<job-send-options>`, e.g. for encrypted sends
 .. |recv-options| replace:: :ref:`recv options<job-recv-options>`
+.. |replication-options| replace:: :ref:`replication options<replication-options>`
+.. |conflict-resolution-options| replace:: :ref:`conflict resolution options<conflict_resolution-options>`
 .. |snapshotting-spec| replace:: :ref:`snapshotting specification <job-snapshotting-spec>`
 .. |pruning-spec| replace:: :ref:`pruning specification <prune>`
 .. |filter-spec| replace:: :ref:`filter specification<pattern-filter>`


### PR DESCRIPTION
Added them to push- and pull-jobs in jobs.rst, seems to have been forgotten? :)