### PR TITLE
keep_bookmarks option was removed

### DIFF
--- a/docs/pr.rst
+++ b/docs/pr.rst
@@ -15,4 +15,5 @@ Talks & Presentations
   `Event <https://wiki.freebsd.org/DevSummit/201709>`__
   )
 
-Note: The problems referenced in the questions with regards to ``keep_bookmarks`` are no longer relevant. Since version `0.4.0 <https://zrepl.github.io/v0.4.0/changelog.html>`__ zrepl only uses a single bookmark from the last sync and the ``keep_bookmarks`` option was removed.
+  * Note: The remarks on ``keep_bookmarks`` are irrelevant as of zrepl 0.1 which introduced the zrepl-managed replication cursor bookmark.
+    Read the `Overview <overview-how-replication-works>`_ section to learn more.

--- a/docs/pr.rst
+++ b/docs/pr.rst
@@ -15,3 +15,4 @@ Talks & Presentations
   `Event <https://wiki.freebsd.org/DevSummit/201709>`__
   )
 
+Note: The problems referenced in the questions with regards to ``keep_bookmarks`` are no longer relevant. Since version `0.4.0 <https://zrepl.github.io/v0.4.0/changelog.html>`__ zrepl only uses a single bookmark from the last sync and the ``keep_bookmarks`` option was removed.


### PR DESCRIPTION
I found the problem regarding ``keep_bookmarks`` confusing and scary but couldn't find further information about this option in the documentation because the option was removed since the talks were given.

This small change adds a note that the keep_bookmarks option was removed in 0.4.0.