### PR TITLE
Fix last_n keep rule (#691)

### DIFF
--- a/pruning/keep_last_n.go
+++ b/pruning/keep_last_n.go
@@ -33,11 +33,6 @@ func NewKeepLastN(n int, regex string) (*KeepLastN, error) {
 }
 
 func (k KeepLastN) KeepRule(snaps []Snapshot) (destroyList []Snapshot) {
-
-	if k.n > len(snaps) {
-		return []Snapshot{}
-	}
-
 	matching, notMatching := partitionSnapList(snaps, func(snapshot Snapshot) bool {
 		return k.re.MatchString(snapshot.Name())
 	})

--- a/pruning/keep_last_n_test.go
+++ b/pruning/keep_last_n_test.go
@@ -90,7 +90,7 @@ func TestKeepLastN(t *testing.T) {
 				stubSnap{"a2", false, o(12)},
 			},
 			rules: []KeepRule{
-				MustKeepLastN(3, "a"),
+				MustKeepLastN(4, "a"),
 			},
 			expDestroy: map[string]bool{
 				"b1": true,


### PR DESCRIPTION
From https://github.com/zrepl/zrepl/issues/691

The last_n prune rule keeps everything, regardless of if it matches the regex or not, if there are less than count snapshot. The expectation would be to never keep non-regex snapshots, regardless of number.