### PR TITLE
Allow same root_fs for different jobs: sinks and so on

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,19 +58,26 @@ commands:
             git config --global user.email "zreplbot@cschwarz.com"
             git config --global user.name "zrepl-github-io-ci"
 
-      # https://circleci.com/docs/2.0/add-ssh-key/#adding-multiple-keys-with-blank-hostnames
-      - run: ssh-add -D
-      # the default circleci ssh config only additional ssh keys for Host !github.com
-      - run:
-          command: |
-            cat > ~/.ssh/config \<<EOF
-            Host *
-              IdentityFile /home/circleci/.ssh/id_rsa_458e62c517f6c480e40452126ce47421
-            EOF
-      - add_ssh_keys:
-          fingerprints:
-            # deploy key for zrepl.github.io
-            - "45:8e:62:c5:17:f6:c4:80:e4:04:52:12:6c:e4:74:21"
+      # if we're pushing, we need to add the deploy key
+      # which is stored as "Additional SSH Keys" in the CircleCI project settings.
+      # We can't use the CircleCI-manage deploy key because we're pushing
+      # to a different repo than the one we're building.
+      - when:
+          condition: << parameters.push >>
+          steps:
+            # https://circleci.com/docs/2.0/add-ssh-key/#adding-multiple-keys-with-blank-hostnames
+            - run: ssh-add -D
+            # the default circleci ssh config only additional ssh keys for Host !github.com
+            - run:
+                command: |
+                  cat > ~/.ssh/config \<<EOF
+                  Host *
+                    IdentityFile /home/circleci/.ssh/id_rsa_458e62c517f6c480e40452126ce47421
+                  EOF
+            - add_ssh_keys:
+                fingerprints:
+                  # deploy key for zrepl.github.io
+                  - "45:8e:62:c5:17:f6:c4:80:e4:04:52:12:6c:e4:74:21"
 
       # caller must install-docdep
       - when:

--- a/daemon/job/build_jobs.go
+++ b/daemon/job/build_jobs.go
@@ -102,7 +102,7 @@ func validateReceivingSidesDoNotOverlap(receivingRootFSs []string) error {
 	// thus,
 	// if any i is prefix of i+n (n >= 1), there is overlap
 	for i := 0; i < len(rfss)-1; i++ {
-		if strings.HasPrefix(rfss[i+1], rfss[i]) {
+		if rfss[i] != rfss[i+1] && strings.HasPrefix(rfss[i+1], rfss[i]) {
 			return fmt.Errorf("receiving jobs with overlapping root filesystems are forbidden")
 		}
 	}

--- a/daemon/job/build_jobs.go
+++ b/daemon/job/build_jobs.go
@@ -102,7 +102,7 @@ func validateReceivingSidesDoNotOverlap(receivingRootFSs []string) error {
 	// thus,
 	// if any i is prefix of i+n (n >= 1), there is overlap
 	for i := 0; i < len(rfss)-1; i++ {
-		if rfss[i] != rfss[i+1] && strings.HasPrefix(rfss[i+1], rfss[i]) {
+		if strings.HasPrefix(rfss[i+1], rfss[i]) {
 			return fmt.Errorf("receiving jobs with overlapping root filesystems are forbidden")
 		}
 	}

--- a/daemon/job/build_jobs.go
+++ b/daemon/job/build_jobs.go
@@ -24,21 +24,6 @@ func JobsFromConfig(c *config.Config, parseFlags config.ParseFlags) ([]Job, erro
 		js[i] = j
 	}
 
-	// receiving-side root filesystems must not overlap
-	{
-		rfss := make([]string, 0, len(js))
-		for _, j := range js {
-			jrfs, ok := j.OwnedDatasetSubtreeRoot()
-			if !ok {
-				continue
-			}
-			rfss = append(rfss, jrfs.ToString())
-		}
-		if err := validateReceivingSidesDoNotOverlap(rfss); err != nil {
-			return nil, err
-		}
-	}
-
 	return js, nil
 }
 

--- a/daemon/job/build_jobs_test.go
+++ b/daemon/job/build_jobs_test.go
@@ -26,16 +26,16 @@ func TestValidateReceivingSidesDoNotOverlap(t *testing.T) {
 		{false, []string{"some/path"}},
 		{false, []string{"zroot/sink1", "zroot/sink2", "zroot/sink3"}},
 		{false, []string{"zroot/foo", "zroot/foobar"}},
-		{true, []string{"zroot/b", "zroot/b"}},
+		{false, []string{"zroot/b", "zroot/b"}},
 		{true, []string{"zroot/foo", "zroot/foo/bar", "zroot/baz"}},
 		{false, []string{"a/x", "b/x"}},
 		{false, []string{"a", "b"}},
-		{true, []string{"a", "a"}},
+		{false, []string{"a", "a"}},
 		{true, []string{"a/x/y", "a/x"}},
 		{true, []string{"a/x", "a/x/y"}},
 		{true, []string{"a/x", "b/x", "a/x/y"}},
 		{true, []string{"a", "a/b", "a/c", "a/b"}},
-		{true, []string{"a/b", "a/c", "a/b", "a/d", "a/c"}},
+		{false, []string{"a/b", "a/c", "a/b", "a/d", "a/c"}},
 	}
 
 	for _, tc := range tcs {

--- a/daemon/job/build_jobs_test.go
+++ b/daemon/job/build_jobs_test.go
@@ -26,16 +26,16 @@ func TestValidateReceivingSidesDoNotOverlap(t *testing.T) {
 		{false, []string{"some/path"}},
 		{false, []string{"zroot/sink1", "zroot/sink2", "zroot/sink3"}},
 		{false, []string{"zroot/foo", "zroot/foobar"}},
-		{false, []string{"zroot/b", "zroot/b"}},
+		{true, []string{"zroot/b", "zroot/b"}},
 		{true, []string{"zroot/foo", "zroot/foo/bar", "zroot/baz"}},
 		{false, []string{"a/x", "b/x"}},
 		{false, []string{"a", "b"}},
-		{false, []string{"a", "a"}},
+		{true, []string{"a", "a"}},
 		{true, []string{"a/x/y", "a/x"}},
 		{true, []string{"a/x", "a/x/y"}},
 		{true, []string{"a/x", "b/x", "a/x/y"}},
 		{true, []string{"a", "a/b", "a/c", "a/b"}},
-		{false, []string{"a/b", "a/c", "a/b", "a/d", "a/c"}},
+		{true, []string{"a/b", "a/c", "a/b", "a/d", "a/c"}},
 	}
 
 	for _, tc := range tcs {

--- a/docs/configuration/overview.rst
+++ b/docs/configuration/overview.rst
@@ -130,7 +130,7 @@ The following high-level steps take place during replication and can be monitore
   * Move the **replication cursor** bookmark on the sending side (see below).
   * Move the **last-received-hold** on the receiving side (see below).
   * Release the send-side step-holds.
-   
+
 The idea behind the execution order of replication steps is that if the sender snapshots all filesystems simultaneously at fixed intervals, the receiver will have all filesystems snapshotted at time ``T1`` before the first snapshot at ``T2 = T1 + $interval`` is replicated.
 
 ZFS Background Knowledge
@@ -258,6 +258,9 @@ On your setup, ensure that
 
 * all ``filesystems`` filter specifications are disjoint
 * no ``root_fs`` is a prefix or equal to another ``root_fs``
+
+  * For ``sink`` jobs, consider all possible ``root_fs/${client_identity}``.
+
 * no ``filesystems`` filter matches any ``root_fs``
 
 **Exceptions to the rule**:


### PR DESCRIPTION
Because some jobs add client identity to root_fs and other jobs don't do that,
we can't reliable detect overlapping of filesystems. And and the same time we
need an ability to use equal or overlapped root_fs for different jobs. For
instance see this config:

```
  - name: "zdisk"
    type: "sink"
    root_fs: "zdisk/zrepl"
    serve:
      type: "local"
      listener_name: "zdisk"
```
and
```
  - name: "remote-to-zdisk"
    type: "pull"
    connect:
      type: "tls"
    root_fs: "zdisk/zrepl/remote"
```

As you can see, two jobs have overlapped root_fs, but actually datasets are not
overlapped, because job `zdisk` save everything under `zdisk/zrepl/localhost`,
because it adds client identity. So they actually use two different filesystems:
`zdisk/zrepl/localhost` and `zdisk/zrepl/remote`. And we can't detect this
situation during config check. So let's just remove this check, because it's
admin's duty to configure correct root_fs's.