### PR TITLE
Add support of shell patterns for filesystems

### DIFF
--- a/daemon/filters/fsmapfilter.go
+++ b/daemon/filters/fsmapfilter.go
@@ -2,6 +2,7 @@ package filters
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -24,6 +25,19 @@ type datasetMapFilterEntry struct {
 	// we have to convert it to the desired rep dynamically
 	mapping      string
 	subtreeMatch bool
+
+	// subtreePattern contains a shell pattern for checking is a subtree matching
+	// this definition or not. See pattern syntax in [filepath.Match].
+	subtreePattern string
+}
+
+func (e datasetMapFilterEntry) HasPattern() bool {
+	return e.subtreePattern != ""
+}
+
+func (e datasetMapFilterEntry) Match(path *zfs.DatasetPath) (bool, error) {
+	fullPattern := filepath.Join(e.path.ToString(), e.subtreePattern)
+	return filepath.Match(fullPattern, path.ToString())
 }
 
 func NewDatasetMapFilter(capacity int, filterMode bool) *DatasetMapFilter {
@@ -43,28 +57,33 @@ func (m *DatasetMapFilter) Add(pathPattern, mapping string) (err error) {
 
 	// assert path glob adheres to spec
 	const SUBTREE_PATTERN string = "<"
-	patternCount := strings.Count(pathPattern, SUBTREE_PATTERN)
-	switch {
-	case patternCount > 1:
-	case patternCount == 1 && !strings.HasSuffix(pathPattern, SUBTREE_PATTERN):
-		err = fmt.Errorf("pattern invalid: only one '<' at end of string allowed")
-		return
+	pathStr, pattern, found := strings.Cut(pathPattern, SUBTREE_PATTERN)
+
+	if pattern != "" {
+		if strings.Contains(pattern, SUBTREE_PATTERN) {
+			return fmt.Errorf(
+				"invalid shell pattern %q in path pattern %q: '<' not allowed in shell patterns",
+				pattern, pathPattern)
+		}
+		if _, err := filepath.Match(pattern, ""); err != nil {
+			return fmt.Errorf(
+				"invalid shell pattern %q in %q: %w", pattern, pathPattern, err)
+		}
 	}
 
-	pathStr := strings.TrimSuffix(pathPattern, SUBTREE_PATTERN)
 	path, err := zfs.NewDatasetPath(pathStr)
 	if err != nil {
 		return fmt.Errorf("pattern is not a dataset path: %s", err)
 	}
 
 	entry := datasetMapFilterEntry{
-		path:         path,
-		mapping:      mapping,
-		subtreeMatch: patternCount > 0,
+		path:           path,
+		mapping:        mapping,
+		subtreeMatch:   found,
+		subtreePattern: pattern,
 	}
 	m.entries = append(m.entries, entry)
 	return
-
 }
 
 // find the most specific prefix mapping we have
@@ -155,9 +174,17 @@ func (m DatasetMapFilter) Filter(p *zfs.DatasetPath) (pass bool, err error) {
 		pass = false
 		return
 	}
+
 	me := m.entries[mi]
-	pass, err = m.parseDatasetFilterResult(me.mapping)
-	return
+	if me.HasPattern() {
+		if matched, err := me.Match(p); err != nil {
+			return false, err
+		} else if !matched {
+			return false, nil
+		}
+	}
+
+	return m.parseDatasetFilterResult(me.mapping)
 }
 
 func (m DatasetMapFilter) UserSpecifiedDatasets() (datasets zfs.UserSpecifiedDatasetsSet) {

--- a/daemon/filters/fsmapfilter_test.go
+++ b/daemon/filters/fsmapfilter_test.go
@@ -54,6 +54,22 @@ func TestDatasetMapFilter(t *testing.T) {
 				"tank/home/bob/downloads": false,
 			},
 		},
+		{
+			name: "with shell patterns",
+			filter: map[string]string{
+				"tank/home</*/foo": "ok",
+				"tank/home/mark<":  "!",
+			},
+			checkPass: map[string]bool{
+				"tank/home":              false,
+				"tank/home/bob":          false,
+				"tank/home/bob/foo":      true,
+				"tank/home/alice/foo":    true,
+				"tank/home/john/foo/bar": false,
+				"tank/home/john/bar":     false,
+				"tank/home/mark/foo":     false,
+			},
+		},
 	}
 
 	for tc := range tcs {

--- a/docs/configuration/filter_syntax.rst
+++ b/docs/configuration/filter_syntax.rst
@@ -15,8 +15,10 @@ The following rules determine which result is chosen for a given filesystem path
 * Non-wildcard patterns (full path patterns) win over *subtree wildcards* (`<` at end of pattern)
 * If the path in question does not match any pattern, the result is ``false``.
 
-The **subtree wildcard** ``<`` means "the dataset left of ``<`` and all its children".
-   
+The **subtree wildcard** ``<`` means "the dataset left of ``<`` and all its
+children". On the right of ``<`` can be added shell pattern, which filters
+children of the dataset.
+
 .. TIP::
   You can try out patterns for a configured job using the ``zrepl test filesystems`` subcommand for push and source jobs.
 
@@ -50,7 +52,8 @@ The following configuration demonstrates all rules presented above.
       filesystems: {
         "tank<": true,          # rule 1
         "tank/foo<": false,     # rule 2
-        "tank/foo/bar": true,  # rule 3
+        "tank/foo/bar": true,   # rule 3
+        "tank/bar</*/foo": true # rule 4
       }
       ...
 
@@ -64,4 +67,7 @@ Which rule applies to given path, and what is the result?
     tank/foo/bar     => 3    true
     zroot            => NONE false
     tank/var/log     => 1    true
-
+    tank/bar/a       => 4    false
+    tank/bar/a/foo   => 4    true
+    tank/bar/b       => 4    false
+    tank/bar/b/foo   => 4    true


### PR DESCRIPTION
Config like
```
filesystems:
  "zroot/jails</*/root": true
```
will include datasets `zroot/jails/a/root` and `zroot/jails/b/root`, but wont
include `zroot/jails/a` and `zroot/jails/b`.