### PR TITLE
Add file logging outlet

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -421,6 +421,13 @@ type LoggingOutletCommon struct {
 	Format string `yaml:"format"`
 }
 
+type FileLoggingOutlet struct {
+	LoggingOutletCommon `yaml:",inline"`
+	FileName            string `yaml:"filename"`
+	Time                bool   `yaml:"time,default=true"`
+	LogLevel            bool   `yaml:"log_level,default=true"`
+}
+
 type StdoutLoggingOutlet struct {
 	LoggingOutletCommon `yaml:",inline"`
 	Time                bool `yaml:"time,default=true"`
@@ -582,6 +589,7 @@ func (t *SnapshottingEnum) UnmarshalYAML(u func(interface{}, bool) error) (err e
 
 func (t *LoggingOutletEnum) UnmarshalYAML(u func(interface{}, bool) error) (err error) {
 	t.Ret, err = enumUnmarshal(u, map[string]interface{}{
+		"file":   &FileLoggingOutlet{},
 		"stdout": &StdoutLoggingOutlet{},
 		"syslog": &SyslogLoggingOutlet{},
 		"tcp":    &TCPLoggingOutlet{},

--- a/config/config.go
+++ b/config/config.go
@@ -426,6 +426,7 @@ type FileLoggingOutlet struct {
 	FileName            string `yaml:"filename"`
 	Time                bool   `yaml:"time,default=true"`
 	LogLevel            bool   `yaml:"log_level,default=true"`
+	Template            string `yaml:"template"`
 }
 
 type StdoutLoggingOutlet struct {

--- a/daemon/logging/build_logging.go
+++ b/daemon/logging/build_logging.go
@@ -325,6 +325,12 @@ func parseFileOutlet(
 		formatter: formatter,
 	}
 
+	if in.Template != "" {
+		if err := outlet.ParseTemplate(in.Template); err != nil {
+			return nil, err
+		}
+	}
+
 	if err := outlet.Open(); err != nil {
 		return nil, err
 	}

--- a/daemon/logging/logging_outlets.go
+++ b/daemon/logging/logging_outlets.go
@@ -191,7 +191,7 @@ func (self *FileOutlet) WriteEntry(entry logger.Entry) error {
 	}
 
 	if err := self.reOpenIfNotExists(); err != nil {
-		return nil
+		return err
 	}
 
 	if self.template == nil {

--- a/daemon/logging/logging_outlets.go
+++ b/daemon/logging/logging_outlets.go
@@ -244,13 +244,7 @@ func (self *FileOutlet) Open() error {
 }
 
 func (self *FileOutlet) ParseTemplate(templateText string) error {
-	funcMap := template.FuncMap{
-		"formatTime": func(t time.Time, layout string) string {
-			return t.Format(layout)
-		},
-	}
-
-	tmpl, err := template.New("").Funcs(funcMap).Parse(templateText)
+	tmpl, err := template.New("").Parse(templateText)
 	if err != nil {
 		return fmt.Errorf("failed parse template %q: %w", templateText, err)
 	}

--- a/daemon/logging/logging_outlets.go
+++ b/daemon/logging/logging_outlets.go
@@ -274,6 +274,10 @@ func (self *FileOutlet) writeTemplate(t time.Time, msg string) error {
 		return fmt.Errorf("failed execute template: %w", err)
 	}
 
+	if _, err := self.writer.Write([]byte("\n")); err != nil {
+		return fmt.Errorf("failed write to %q: %w", self.filename, err)
+	}
+
 	return nil
 }
 

--- a/docs/configuration/logging.rst
+++ b/docs/configuration/logging.rst
@@ -129,10 +129,28 @@ Outlets are the destination for log entries.
       - include log level into output (``true`` or ``false``). Default is ``true``.
     * - ``filename``
       - path of the log file
+    * - ``template``
+      - format output by Go template string
 
 Writes all log entries with minimum level ``level`` formatted by ``format`` to
 file from ``filename``. This outlet automatically detects the log file was
 rotated and reopens it.
+
+If ``template`` configured, log entries formatted by this template. For instance
+this configuration
+
+::
+
+    - type: "file"
+      level:  "info"
+      format: "human"
+      filename: "/var/log/zrepl.log"
+      time: false
+      template: '{{formatTime .Time "Jan _2 15:04:05"}} zrepl[{{.Pid}}]: {{.Message}}'
+
+formats log entries like ::
+
+  ``Oct 22 21:51:02 zrepl[29094]: [INFO][job-name][job][abcd$dcab$abcd.dcab]: wait for wakeups``.
 
 Can be specified many times with different ``filename``.
 

--- a/docs/configuration/logging.rst
+++ b/docs/configuration/logging.rst
@@ -146,7 +146,7 @@ For instance this configuration
       format: "human"
       filename: "/var/log/zrepl.log"
       time: false
-      template: '{{formatTime .Time "Jan _2 15:04:05"}} zrepl[{{.Pid}}]: {{.Message}}'
+      template: '{{.Time.Format "Jan _2 15:04:05"}} zrepl[{{.Pid}}]: {{.Message}}'
 
 formats log entries like ::
 

--- a/docs/configuration/logging.rst
+++ b/docs/configuration/logging.rst
@@ -136,8 +136,8 @@ Writes all log entries with minimum level ``level`` formatted by ``format`` to
 file from ``filename``. This outlet automatically detects the log file was
 rotated and reopens it.
 
-If ``template`` configured, log entries formatted by this template. For instance
-this configuration
+If ``template`` is configured, log entries are formatted using this template.
+For instance this configuration
 
 ::
 

--- a/docs/configuration/logging.rst
+++ b/docs/configuration/logging.rst
@@ -106,6 +106,36 @@ Outlets
 
 Outlets are the destination for log entries.
 
+.. _logging-outlet-file:
+
+``file`` Outlet
+-----------------
+
+.. list-table::
+    :widths: 10 90
+    :header-rows: 1
+
+    * - Parameter
+      - Comment
+    * - ``type``
+      - ``file``
+    * - ``level``
+      -  minimum  :ref:`log level <logging-levels>`
+    * - ``format``
+      - output :ref:`format <logging-formats>`
+    * - ``time``
+      - always include time in output (``true`` or ``false``). Default is ``true``.
+    * - ``log_level``
+      - include log level into output (``true`` or ``false``). Default is ``true``.
+    * - ``filename``
+      - path of the log file
+
+Writes all log entries with minimum level ``level`` formatted by ``format`` to
+file from ``filename``. This outlet automatically detects the log file was
+rotated and reopens it.
+
+Can be specified many times with different ``filename``.
+
 .. _logging-outlet-stdout:
 
 ``stdout`` Outlet


### PR DESCRIPTION
Writes all log entries with minimum level `level` formatted by `format` to file from `filename`. This outlet automatically detects the log file was rotated and reopens it.

`time` and `log_level` are `true` by default.

Can be specified many times with different `filename`.

An example of configuration:
```
    - type: "file"
      level:  "info"
      format: "human"
      time: true
      log_level: true
      filename: "/var/log/zrepl.log"
```

Another example using `template`:
```
    - type: "file"
      level:  "info"
      format: "human"
      filename: "/var/log/zrepl.log"
      time: false
      template: '{{formatTime .Time "Jan _2 15:04:05"}} zrepl[{{.Pid}}]: {{.Message}}'
```

It formats log entries like
```
Oct 22 21:51:02 zrepl[29094]: [INFO][job-name][job][abcd$dcab$abcd.dcab]: wait for wakeups
```