### PR TITLE
Implement `interval` for manual push jobs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -146,9 +146,10 @@ type PlaceholderRecvOptions struct {
 
 type PushJob struct {
 	ActiveJob    `yaml:",inline"`
-	Snapshotting SnapshottingEnum  `yaml:"snapshotting"`
-	Filesystems  FilesystemsFilter `yaml:"filesystems"`
-	Send         *SendOptions      `yaml:"send,fromdefaults,optional"`
+	Interval     *PositiveDurationOrManual `yaml:"interval,optional"`
+	Snapshotting SnapshottingEnum          `yaml:"snapshotting"`
+	Filesystems  FilesystemsFilter         `yaml:"filesystems"`
+	Send         *SendOptions              `yaml:"send,fromdefaults,optional"`
 }
 
 func (j *PushJob) GetFilesystems() FilesystemsFilter { return j.Filesystems }

--- a/docs/configuration/jobs.rst
+++ b/docs/configuration/jobs.rst
@@ -24,8 +24,13 @@ Job Type ``push``
       - |connect-transport|
     * - ``filesystems``
       - |filter-spec| for filesystems to be snapshotted and pushed to the sink
+    * - ``interval``
+      - | Interval at which to push to the sink (e.g. ``10m``) if
+        | ``snapshotting`` configured as ``manual``. This field is optional and
+        | if not defined, than ``snapshotting`` does the job. Also this field
+        | ignored if ``snapshotting`` isn't ``manual``.
     * - ``send``
-      - |send-options| 
+      - |send-options|
     * - ``snapshotting``
       - |snapshotting-spec|
     * - ``pruning``


### PR DESCRIPTION
Here is an example of configuration:
```
  - name: "zroot-to-remote"
    type: "push"
    connect:
      type: "tls"
      address: "remote:8888"
    filesystems: *filesystems
    interval: "1h"
    send:
      compressed: true
    conflict_resolution:
      initial_replication: "all"
    snapshotting:
      type: "manual"
    pruning: &pruning-remote
      keep_sender:
        - type: "regex"
          regex: ".*"
      keep_receiver: *keep-receiver
```
which doesn't do snapshots and just replicates `filesystems` every hour.