### PR TITLE
Add piping into zfs send|recv

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -98,6 +98,7 @@ type SendOptions struct {
 	Saved            bool `yaml:"saved,optional,default=false"`
 
 	BandwidthLimit *BandwidthLimit `yaml:"bandwidth_limit,optional,fromdefaults"`
+	ExecPipe       [][]string      `yaml:"execpipe,optional"`
 }
 
 type RecvOptions struct {
@@ -111,6 +112,8 @@ type RecvOptions struct {
 	BandwidthLimit *BandwidthLimit `yaml:"bandwidth_limit,optional,fromdefaults"`
 
 	Placeholder *PlaceholderRecvOptions `yaml:"placeholder,fromdefaults"`
+
+	ExecPipe [][]string `yaml:"execpipe,optional"`
 }
 
 var _ yaml.Unmarshaler = &datasizeunit.Bits{}

--- a/daemon/job/build_jobs_sendrecvoptions.go
+++ b/daemon/job/build_jobs_sendrecvoptions.go
@@ -41,6 +41,7 @@ func buildSenderConfig(in SendingJobConfig, jobID endpoint.JobID) (*endpoint.Sen
 		SendSaved:            sendOpts.Saved,
 
 		BandwidthLimit: bwlim,
+		ExecPipe:       sendOpts.ExecPipe,
 	}
 
 	if err := sc.Validate(); err != nil {
@@ -93,7 +94,9 @@ func buildReceiverConfig(in ReceivingJobConfig, jobID endpoint.JobID) (rc endpoi
 		BandwidthLimit: bwlim,
 
 		PlaceholderEncryption: placeholderEncryption,
+		ExecPipe:              recvOpts.ExecPipe,
 	}
+
 	if err := rc.Validate(); err != nil {
 		return rc, errors.Wrap(err, "cannot build receiver config")
 	}

--- a/docs/configuration/sendrecvoptions.rst
+++ b/docs/configuration/sendrecvoptions.rst
@@ -304,9 +304,9 @@ Command Pipe (send & recv)
 ::
    recv:
      execpipe:
-       # unzstd | mbuffer | zfs receive
-       - [ "unzstd" ]
+       # mbuffer | unzstd | zfs receive
        - [ "/usr/local/bin/mbuffer", "-q", "-s", "128k", "-m", "100M" ]
+       - [ "unzstd" ]
 
 Usually it executes standalone ``zfs send`` or ``zfs recv``, but using
 ``execpipe`` we can configure it to send stdout of ``zfs send`` to another


### PR DESCRIPTION
Use case is I'd like `zfs send` will actually do
```
zfs send | mbuffer -q -s 128k -m16M
```

and the same about `zfs receive`. Configuration looks like:
```
  - name: "remote-to-zdisk"
    type: "pull"
    connect:
      type: "tls"
      address: "remote:8888"
    recv:
      execpipe:
        # mbuffer | unzstd | zfs receive
        - [ "mbuffer", "-q", "-s", "128k", "-m", "16M" ]
        - [ "unzstd" ]
```

or
```
  - name: "zroot-to-remote"
    type: "push"
    connect:
      type: "tls"
      address: "remote:8888"
    send:
      execpipe:
        # zfs send | zstd -3 | mbuffer
        - [ "zstd", "-3" ]
        - [ "mbuffer", "-q", "-s", "128k", "-m", "16M" ]
```

Usually it executes standalone `zfs send` or `zfs recv`, but using `execpipe` we can configure it to send stdout of `zfs send` to another programm(s) or send stdout of another programm(s) to `zfs recv`.

This change adds new field `execpipe` into `send` and `recv`, which is seq of seq.