### PR TITLE
allow entering time zone in timestamp_format and actually see it

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -219,11 +219,12 @@ type SnapshottingEnum struct {
 }
 
 type SnapshottingPeriodic struct {
-	Type            string            `yaml:"type"`
-	Prefix          string            `yaml:"prefix"`
-	Interval        *PositiveDuration `yaml:"interval"`
-	Hooks           HookList          `yaml:"hooks,optional"`
-	TimestampFormat string            `yaml:"timestamp_format,optional,default=dense"`
+	Type              string            `yaml:"type"`
+	Prefix            string            `yaml:"prefix"`
+	Interval          *PositiveDuration `yaml:"interval"`
+	Hooks             HookList          `yaml:"hooks,optional"`
+	TimestampFormat   string            `yaml:"timestamp_format,optional,default=dense"`
+	TimestampLocation string            `yaml:"timestamp_location,optional,default=UTC"`
 }
 
 type CronSpec struct {
@@ -252,11 +253,12 @@ func (s *CronSpec) UnmarshalYAML(unmarshal func(v interface{}, not_strict bool) 
 }
 
 type SnapshottingCron struct {
-	Type            string   `yaml:"type"`
-	Prefix          string   `yaml:"prefix"`
-	Cron            CronSpec `yaml:"cron"`
-	Hooks           HookList `yaml:"hooks,optional"`
-	TimestampFormat string   `yaml:"timestamp_format,optional,default=dense"`
+	Type              string   `yaml:"type"`
+	Prefix            string   `yaml:"prefix"`
+	Cron              CronSpec `yaml:"cron"`
+	Hooks             HookList `yaml:"hooks,optional"`
+	TimestampFormat   string   `yaml:"timestamp_format,optional,default=dense"`
+	TimestampLocation string   `yaml:"timestamp_location,optional,default=UTC"`
 }
 
 type SnapshottingManual struct {

--- a/daemon/snapper/cron.go
+++ b/daemon/snapper/cron.go
@@ -21,9 +21,10 @@ func cronFromConfig(fsf zfs.DatasetFilter, in config.SnapshottingCron) (*Cron, e
 		return nil, errors.Wrap(err, "hook config error")
 	}
 	planArgs := planArgs{
-		prefix:          in.Prefix,
-		timestampFormat: in.TimestampFormat,
-		hooks:           hooksList,
+		prefix:            in.Prefix,
+		timestampFormat:   in.TimestampFormat,
+		timestampLocation: in.TimestampLocation,
+		hooks:             hooksList,
 	}
 	return &Cron{config: in, fsf: fsf, planArgs: planArgs}, nil
 }

--- a/daemon/snapper/impl.go
+++ b/daemon/snapper/impl.go
@@ -61,7 +61,10 @@ type snapProgress struct {
 }
 
 func (plan *plan) formatNow(format string) string {
-	now := time.Now().UTC()
+	now := time.Now()
+	if !(strings.Contains(format, "-07") || strings.Contains(format, "Z07") || strings.Contains(format, "MST")) {
+		now = now.UTC()
+	}
 	switch strings.ToLower(format) {
 	case "dense":
 		format = "20060102_150405_000"
@@ -72,7 +75,7 @@ func (plan *plan) formatNow(format string) string {
 	case "unix-seconds":
 		return strconv.FormatInt(now.Unix(), 10)
 	}
-	return now.Format(format)
+	return strings.Replace(now.Format(format), "+", "_", -1)
 }
 
 func (plan *plan) execute(ctx context.Context, dryRun bool) (ok bool) {

--- a/daemon/snapper/periodic.go
+++ b/daemon/snapper/periodic.go
@@ -36,9 +36,10 @@ func periodicFromConfig(g *config.Global, fsf zfs.DatasetFilter, in *config.Snap
 		interval: in.Interval.Duration(),
 		fsf:      fsf,
 		planArgs: planArgs{
-			prefix:          in.Prefix,
-			timestampFormat: in.TimestampFormat,
-			hooks:           hookList,
+			prefix:            in.Prefix,
+			timestampFormat:   in.TimestampFormat,
+			timestampLocation: in.TimestampLocation,
+			hooks:             hookList,
 		},
 		// ctx and log is set in Run()
 	}

--- a/docs/configuration/snapshotting.rst
+++ b/docs/configuration/snapshotting.rst
@@ -25,8 +25,9 @@ The following snapshotting types are supported:
 
 The ``periodic`` and ``cron`` snapshotting types share some common options and behavior:
 
-* **Naming:** The snapshot names are composed of a user-defined ``prefix`` followed by a UTC date formatted like ``20060102_150405_000``.
-  We use UTC because it will avoid name conflicts when switching time zones or between summer and winter time.
+* **Naming:** The snapshot names are composed of a user-defined ``prefix`` followed by a UTC date formatted like ``20060102_150405_000`` by default.
+  We either use UTC or timestamp with timezone information because it will avoid name conflicts when switching time zones or between summer and winter time.
+  Note that if timestamp with time zone information is used, the "+" of the timezone (i.e. +02:00) is replaced by "_" (i.e. _02:00) to conform to allowed characters in ZFS snapshots.
 * **Hooks:** You can configure hooks to run before or after zrepl takes the snapshots. See :ref:`below <job-snapshotting-hooks>` for details.
 * **Push replication:** After creating all snapshots, the snapshotter will wake up the replication part of the job, if it's a ``push`` job.
   Note that snapshotting is decoupled from replication, i.e., if it is down or takes too long, snapshots will still be taken.
@@ -65,6 +66,9 @@ The ``periodic`` and ``cron`` snapshotting types share some common options and b
        # Timestamp format that is used as snapshot suffix.
        # Can be any of "dense" (default), "human", "iso-8601", "unix-seconds" or a custom Go time format (see https://go.dev/src/time/format.go)
        timestamp_format: dense
+       # Specifies in which time zone the snapshot suffix is generated, optional, defaults to UTC, used only if time zone information is part of timestamp_format.
+       # Can be "UTC" (default), "Local" (time zone information from the OS) or any of the IANA Time Zone names (see https://nodatime.org/TimeZones)
+       timestamp_location: UTC
        hooks: ...
     pruning: ...
 
@@ -97,6 +101,9 @@ The snapshotter uses the ``prefix`` to identify which snapshots it created.
        # Timestamp format that is used as snapshot suffix.
        # Can be any of "dense" (default), "human", "iso-8601", "unix-seconds" or a custom Go time format (see https://go.dev/src/time/format.go)
        timestamp_format: dense
+       # Specifies in which time zone the snapshot suffix is generated, optional, defaults to UTC, used only if time zone information is part of timestamp_format.
+       # Can be "UTC" (default), "Local" (time zone information from the OS) or any of the IANA Time Zone names (see https://nodatime.org/TimeZones)
+       timestamp_location: UTC
      pruning: ...
 
 In ``cron`` mode, the snapshotter takes snaphots at fixed points in time.
@@ -117,6 +124,11 @@ It can be used by setting ``timestamp_format`` to any of the following values:
 * ``iso-8601`` looks like ``2006-01-02T15:04:05.000Z``
 * ``unix-seconds`` looks like ``1136214245``
 * Any custom Go time format accepted by `time.Time#Format <https://go.dev/src/time/format.go>`_.
+
+If timestamp suffix for snapshot name is desired in local or another timezone, please:
+
+* specify ``timestamp_format`` with timezone information, for example ``2006-01-02T15:04:05Z0700`` or ``2006-01-02T15:04:05MST``
+* specify ``timestamp_location`` to be other than ``UTC``, for example ``Local`` or ``Europe/Riga``
 
 
 ``manual`` Snapshotting


### PR DESCRIPTION
  if one lives in UK, UTC time zone is fine, because it matches
  local time for that user, however, if user lives somewhere else
  and quickly wants to restore a file from that particular time, he
  has to go through some mental gymnastics to calculate which time
  is the right time, because everything is stored in UTC

  for scripts, that might not be a problem, however for user, he
  interprets time as his local time, not UTC

  this patch allows user to enter and actually see the actual local
  time with TZ as a snapshot name, either numeric or otherwise
  if user did not ask for time zone, he still will get the default
  time in UTC in snapshot name

  there were couple of nuances with numeric time zones, because
  they contain - or +, - is allowed character in snapshot name,
  however + is not, so just replace + with _