### PR TITLE
treat empty `jobs` & empty YAML as valid & ship empty `jobs` in deb/rpm

### DIFF
--- a/config/config_minimal_test.go
+++ b/config/config_minimal_test.go
@@ -2,15 +2,7 @@ package config
 
 import (
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
-
-func TestConfigEmptyFails(t *testing.T) {
-	conf, err := testConfig(t, "\n")
-	assert.Nil(t, conf)
-	assert.Error(t, err)
-}
 
 func TestJobsOnlyWorks(t *testing.T) {
 	testValidConfig(t, `
@@ -34,7 +26,7 @@ jobs:
     keep_sender:
     - type: not_replicated
     keep_receiver:
-    - type: last_n 
+    - type: last_n
       count: 1
 `)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -84,7 +84,7 @@ func trimSpaceEachLineAndPad(s, pad string) string {
 func TestTrimSpaceEachLineAndPad(t *testing.T) {
 	foo := `
 	foo
-	bar baz 
+	bar baz
 	`
 	assert.Equal(t, "  \n  foo\n  bar baz\n  \n", trimSpaceEachLineAndPad(foo, "  "))
 }
@@ -137,4 +137,19 @@ func TestCronSpec(t *testing.T) {
 		})
 	}
 
+}
+
+func TestEmptyConfig(t *testing.T) {
+	cases := []string{
+		"",
+		"\n",
+		"---",
+		"---\n",
+	}
+	for _, input := range cases {
+		config := testValidConfig(t, input)
+		require.NotNil(t, config)
+		require.NotNil(t, config.Global)
+		require.Empty(t, config.Jobs)
+	}
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -22,6 +22,8 @@ func TestSampleConfigsAreParsedWithoutErrors(t *testing.T) {
 		t.Errorf("glob failed: %+v", err)
 	}
 
+	paths = append(paths, "../packaging/systemd-default-zrepl.yml")
+
 	for _, p := range paths {
 
 		if path.Ext(p) != ".yml" {

--- a/packaging/systemd-default-zrepl.yml
+++ b/packaging/systemd-default-zrepl.yml
@@ -5,9 +5,7 @@ global:
       format: human
       level: warn
 
-jobs:
-#  - name: foo
-#    type: bar
+jobs: []
 
 # see USR_SHARE_ZREPL/examples
 # or https://zrepl.github.io/configuration/overview.html


### PR DESCRIPTION
fixes https://github.com/zrepl/zrepl/issues/784
obsoletes https://github.com/zrepl/zrepl/pull/787