### PR TITLE
Serve Prometheus metrics over (m)TLS

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -439,9 +439,10 @@ type MonitoringEnum struct {
 }
 
 type PrometheusMonitoring struct {
-	Type           string `yaml:"type"`
-	Listen         string `yaml:"listen,hostport"`
-	ListenFreeBind bool   `yaml:"listen_freebind,default=false"`
+	Type           string     `yaml:"type"`
+	Listen         string     `yaml:"listen,hostport"`
+	ListenFreeBind bool       `yaml:"listen_freebind,default=false"`
+	TLS            *TLSConfig `yaml:"tls,optional"`
 }
 
 type SyslogFacility syslog.Priority

--- a/config/tls.go
+++ b/config/tls.go
@@ -1,0 +1,160 @@
+package config
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/pkg/errors"
+)
+
+type TLSConfig struct {
+	CertPath     string         `yaml:"cert"`
+	KeyPath      string         `yaml:"key"`
+	ClientCAs    string         `yaml:"client_ca,optional"`
+	ClientAuth   ClientAuthType `yaml:"client_auth_type,optional"`
+	MinVersion   TLSVersion     `yaml:"min_version,optional"`
+	MaxVersion   TLSVersion     `yaml:"max_version,optional"`
+	CipherSuites []CipherSuite  `yaml:"cipher_suites,optional"`
+}
+
+func (c *TLSConfig) loadCertificate() (*tls.Certificate, error) {
+	cert, err := ioutil.ReadFile(c.CertPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "tls: failed to read certificate")
+	}
+	key, err := ioutil.ReadFile(c.KeyPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "tls: failed to read key")
+	}
+
+	merged, err := tls.X509KeyPair(cert, key)
+	if err != nil {
+		return nil, errors.Wrap(err, "tls: failed to load X509KeyPair")
+	}
+	return &merged, nil
+}
+
+func (c *TLSConfig) Config() (*tls.Config, error) {
+	if c == nil {
+		return nil, nil
+	}
+
+	if c.CertPath == "" {
+		return nil, errors.New("tls: missing cert path")
+	}
+	if c.KeyPath == "" {
+		return nil, errors.New("tls: missing key path")
+	}
+
+	_, err := c.loadCertificate()
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := tls.Config{
+		MinVersion: c.MinVersion.Value(),
+		MaxVersion: c.MaxVersion.Value(),
+		ClientAuth: c.ClientAuth.Value(),
+		GetCertificate: func(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+			return c.loadCertificate()
+		},
+		PreferServerCipherSuites: true,
+	}
+
+	if c.ClientCAs != "" {
+		if cfg.ClientAuth == tls.NoClientCert {
+			return nil, errors.New("tls: client CAs set but client_auth_type is not set")
+		}
+
+		pool := x509.NewCertPool()
+		cas, err := ioutil.ReadFile(c.ClientCAs)
+		if err != nil {
+			return nil, err
+		}
+		pool.AppendCertsFromPEM(cas)
+		cfg.ClientCAs = pool
+	}
+
+	if len(c.CipherSuites) > 0 {
+		cfg.CipherSuites = make([]uint16, len(c.CipherSuites))
+		for i, cs := range c.CipherSuites {
+			cfg.CipherSuites[i] = cs.Value()
+		}
+	}
+
+	return &cfg, nil
+}
+
+type TLSVersion uint16
+
+var tlsVersions = map[string]TLSVersion{
+	"TLS1.3": (TLSVersion)(tls.VersionTLS13),
+	"TLS1.2": (TLSVersion)(tls.VersionTLS12),
+	"TLS1.1": (TLSVersion)(tls.VersionTLS11),
+	"TLS1.0": (TLSVersion)(tls.VersionTLS10),
+}
+
+func (tv *TLSVersion) Value() uint16 {
+	return uint16(*tv)
+}
+
+func (tv *TLSVersion) UnmarshalText(data []byte) error {
+	s := string(data)
+	if v, ok := tlsVersions[s]; ok {
+		*tv = v
+		return nil
+	}
+	return fmt.Errorf("unknown TLS version: " + s)
+}
+
+func (tv *TLSVersion) MarshalText() (text []byte, err error) {
+	for s, v := range tlsVersions {
+		if *tv == v {
+			return []byte(s), nil
+		}
+	}
+	return nil, fmt.Errorf("unknown TLS version: %v", *tv)
+}
+
+type ClientAuthType tls.ClientAuthType
+
+func (c *ClientAuthType) Value() tls.ClientAuthType {
+	return (tls.ClientAuthType)(*c)
+}
+
+func (c *ClientAuthType) UnmarshalText(text []byte) error {
+	switch string(text) {
+	case "", "NoClientCert":
+		*c = ClientAuthType(tls.NoClientCert)
+	case "RequestClientCert":
+		*c = ClientAuthType(tls.RequestClientCert)
+	case "RequireAnyClientCert":
+		*c = ClientAuthType(tls.RequireAnyClientCert)
+	case "VerifyClientCertIfGiven":
+		*c = ClientAuthType(tls.VerifyClientCertIfGiven)
+	case "RequireAndVerifyClientCert":
+		*c = ClientAuthType(tls.RequireAndVerifyClientCert)
+	default:
+		return errors.Errorf("invalid ClientAuthType: %s", text)
+	}
+	return nil
+}
+
+type CipherSuite uint16
+
+func (c *CipherSuite) Value() uint16 {
+	return uint16(*c)
+}
+
+func (c *CipherSuite) UnmarshalText(text []byte) error {
+	s := string(text)
+	for _, cs := range tls.CipherSuites() {
+		if cs.Name == s {
+			*c = (CipherSuite)(cs.ID)
+			return nil
+		}
+	}
+	return errors.Errorf("unknown cipher: %s", s)
+}

--- a/config/tls_test.go
+++ b/config/tls_test.go
@@ -1,0 +1,179 @@
+package config
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/zrepl/yaml-config"
+)
+
+func TestTLSConfig(t *testing.T) {
+	input := `
+cert: path/to/cert.pem
+key: path/to/key.pem
+client_ca: path/to/ca.pem
+client_auth_type: RequireAndVerifyClientCert
+min_version: TLS1.0
+max_version: TLS1.3
+cipher_suites:
+  # TLS 1.2 cipher suites.
+  - TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
+  - TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
+  - TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+  - TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+  - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+  - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+  - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+  - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+  - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+  - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+  # TLS 1.3 cipher suites.
+  - TLS_AES_128_GCM_SHA256
+  - TLS_AES_256_GCM_SHA384
+  - TLS_CHACHA20_POLY1305_SHA256
+`
+	parsed := TLSConfig{
+		CertPath:   "path/to/cert.pem",
+		KeyPath:    "path/to/key.pem",
+		ClientCAs:  "path/to/ca.pem",
+		ClientAuth: ClientAuthType(tls.RequireAndVerifyClientCert),
+		MinVersion: tls.VersionTLS10,
+		MaxVersion: tls.VersionTLS13,
+		CipherSuites: []CipherSuite{
+			// TLS 1.2 cipher suites.
+			CipherSuite(tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA),
+			CipherSuite(tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA),
+			CipherSuite(tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA),
+			CipherSuite(tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA),
+			CipherSuite(tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256),
+			CipherSuite(tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384),
+			CipherSuite(tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256),
+			CipherSuite(tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384),
+			CipherSuite(tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256),
+			CipherSuite(tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256),
+			// TLS 1.3 cipher suites.
+			CipherSuite(tls.TLS_AES_128_GCM_SHA256),
+			CipherSuite(tls.TLS_AES_256_GCM_SHA384),
+			CipherSuite(tls.TLS_CHACHA20_POLY1305_SHA256),
+		},
+	}
+
+	var actual TLSConfig
+	err := yaml.Unmarshal([]byte(input), &actual)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(actual, parsed) {
+		t.Fatal("parsed TLS config doesn't match expected")
+	}
+
+	workdir := t.TempDir()
+	pathTo := path.Join(workdir, "path", "to")
+	err = os.MkdirAll(pathTo, os.FileMode(0755))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Generate private key and x509 certificate, valid enough to make the TLS
+	// code load them for testing.
+	key, cert, err := genKeyCert( /* validFor */ time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writePEMFile(t, path.Join(pathTo, "cert.pem"), os.FileMode(0644), "CERTIFICATE", cert)
+	writePEMFile(t, path.Join(pathTo, "key.pem"), os.FileMode(0644), "PRIVATE KEY", key)
+	// write the "leaf" cert to the CA path- it doesn't matter that it doesn't
+	// actually sign the cert (we never check)- just that it's a valid
+	// PEM-encoded x509 certificate
+	writePEMFile(t, path.Join(pathTo, "ca.pem"), os.FileMode(0644), "CERTIFICATE", cert)
+
+	if os.Chdir(workdir) != nil {
+		t.Fatal("failed to change chdir to " + workdir)
+	}
+	config, err := parsed.Config()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedCipherSuites := make([]uint16, len(parsed.CipherSuites))
+	for i, cs := range parsed.CipherSuites {
+		expectedCipherSuites[i] = uint16(cs)
+	}
+
+	matches := []struct {
+		name             string
+		expected, actual interface{}
+	}{
+		{"CipherSuites", expectedCipherSuites, config.CipherSuites},
+		{"MinVersion", uint16(tls.VersionTLS10), config.MinVersion},
+		{"MaxVersion", uint16(tls.VersionTLS13), config.MaxVersion},
+	}
+	for _, match := range matches {
+		if !reflect.DeepEqual(match.expected, match.actual) {
+			t.Fatalf("expected and actual %s do not match", match.name)
+		}
+	}
+
+	actualClientCAs := x509.NewCertPool()
+	actualClientCAs.AppendCertsFromPEM(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert}))
+	if !config.ClientCAs.Equal(actualClientCAs) {
+		t.Fatalf("expected and actual client CAs do not match")
+	}
+}
+
+// genKeyCert generates an elliptic curve and self-signed certificate for
+// testing. key and certificate are returned in DER format, as bytes.
+func genKeyCert(validFor time.Duration) ([]byte, []byte, error) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, err
+	}
+	key, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	notBefore := time.Now()
+	template := x509.Certificate{
+		SerialNumber:          big.NewInt(0),
+		Subject:               pkix.Name{CommonName: "localhost"},
+		SignatureAlgorithm:    x509.ECDSAWithSHA256,
+		NotBefore:             notBefore,
+		NotAfter:              notBefore.Add(validFor),
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	cert, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return key, cert, nil
+}
+
+func writePEMFile(t *testing.T, path string, mode os.FileMode, typ string, cert []byte) {
+	open, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = pem.Encode(open, &pem.Block{Type: typ, Bytes: cert})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = open.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/daemon/prometheus.go
+++ b/daemon/prometheus.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"crypto/tls"
 	"net"
 	"net/http"
 
@@ -21,13 +22,18 @@ import (
 type prometheusJob struct {
 	listen   string
 	freeBind bool
+	tls      *tls.Config
 }
 
 func newPrometheusJobFromConfig(in *config.PrometheusMonitoring) (*prometheusJob, error) {
 	if _, _, err := net.SplitHostPort(in.Listen); err != nil {
 		return nil, err
 	}
-	return &prometheusJob{in.Listen, in.ListenFreeBind}, nil
+	tlsConfig, err := in.TLS.Config()
+	if err != nil {
+		return nil, err
+	}
+	return &prometheusJob{in.Listen, in.ListenFreeBind, tlsConfig}, nil
 }
 
 var prom struct {
@@ -79,7 +85,16 @@ func (j *prometheusJob) Run(ctx context.Context) {
 	mux := http.NewServeMux()
 	mux.Handle("/metrics", promhttp.Handler())
 
-	err = http.Serve(l, mux)
+	server := &http.Server{
+		Handler:   mux,
+		TLSConfig: j.tls,
+	}
+
+	if j.tls != nil {
+		err = server.ServeTLS(l, "", "")
+	} else {
+		err = server.Serve(l)
+	}
 	if err != nil && ctx.Err() == nil {
 		log.WithError(err).Error("error while serving")
 	}


### PR DESCRIPTION
Add a TLSConfig struct/library to configure a simple TLS/HTTPS server with most basic toggles that most users would want. This is based on the structure that the prometheus/exporter-toolkit web-config uses.

Notably this does not make use of either of the two existing TLS configuration structures that exist as both are specific in their usage and neither are suitable for generally configuring a TLS server.