### PR TITLE
deb: place bash completion at correct path, using debhelper

### DIFF
--- a/packaging/deb/Dockerfile
+++ b/packaging/deb/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update && apt-get install -y \
 	build-essential \
     devscripts \
     dh-exec \
+	bash-completion \
 	binutils-aarch64-linux-gnu \
 	binutils-arm-linux-gnueabihf  \
 	binutils-i686-linux-gnu \

--- a/packaging/deb/debian/control
+++ b/packaging/deb/debian/control
@@ -1,6 +1,6 @@
 Source: zrepl
 Maintainer: Christian Schwarz <me@cschwarz.com>
-Build-Depends: dh-exec
+Build-Depends: dh-exec, bash-completion
 
 Package: zrepl
 Architecture: arm64 amd64 armhf i386

--- a/packaging/deb/debian/rules
+++ b/packaging/deb/debian/rules
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 
 %:
-	dh $@
+	dh $@ --with bash-completion
 
 override_dh_strip:
 
@@ -26,8 +26,9 @@ override_dh_auto_install:
 	cp --preserve=all artifacts/$(ZREPL_DPKG_ZREPL_BINARY_FILENAME) debian/renamedir/zrepl
 	dh_install debian/renamedir/zrepl usr/bin
 
-	# install bash completion
-	dh_install artifacts/bash_completion etc/bash_completion.d/zrepl
+	# install zsh completions
+	# NB: bash completion auto-magic via dh_bash-completion
+	# TODO: unify on https://tracker.debian.org/pkg/dh-shell-completions when available
 	dh_install artifacts/_zrepl.zsh_completion usr/share/zsh/vendor-completions
 
 	# install docs

--- a/packaging/deb/debian/zrepl.bash-completion
+++ b/packaging/deb/debian/zrepl.bash-completion
@@ -1,0 +1,1 @@
+artifacts/bash_completion zrepl


### PR DESCRIPTION
fixes https://github.com/zrepl/zrepl/issues/794