### PR TITLE
Docs: add san subject-alt-name to the easyrsa script

### DIFF
--- a/docs/configuration/transports.rst
+++ b/docs/configuration/transports.rst
@@ -230,7 +230,7 @@ Tools like `EasyRSA <https://github.com/OpenVPN/easy-rsa>`_ make this very easy:
      ./easyrsa build-ca nopass
 
      for host in "${HOSTS[@]}"; do
-         ./easyrsa build-serverClient-full $host nopass
+         ./easyrsa --subject-alt-name=DNS:$host build-serverClient-full $host nopass
          echo cert for host $host available at pki/issued/$host.crt
          echo key for host $host available at pki/private/$host.key
      done


### PR DESCRIPTION
The current easyrsa script is not compatible with zrepl 0.3.0 and newer because of the missing san entry.