### PR TITLE
build: rpm: build with almalinux:8 image instead of fedora:latest, fixing `make rpm-build`

### DIFF
--- a/packaging/rpm/Dockerfile
+++ b/packaging/rpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:latest
+FROM almalinux:8
 
 RUN dnf install -y git make bash rpm-build 'dnf-command(builddep)'
 ADD packaging/rpm/zrepl.spec /tmp/zrepl.spec


### PR DESCRIPTION
The `make rpm-build` started failing with

```
find-debuginfo: starting
Extracting debug info from 1 files
*** ERROR: No build ID note found in /build/src/artifacts/rpmbuild/BUILD/zrepl-v0.6.1.47.gbae2bd2-build/BUILDROOT/usr/bin/zrepl
error: Bad exit status from /var/tmp/rpm-tmp.bYHLzG (%install)
```

This must be a change in Fedora (prob new Fedora major release).

Seize the opportunity to
1. stop building from `:latest`, and
2. build with an LTS RPM distro to improve zrepl RPM compatibility (no problems so far AFAIK but this seems sensible)