### PR TITLE
docs: correct EasyRSA command for TLS with `--subject-alt-name`

### DIFF
--- a/docs/configuration/transports.rst
+++ b/docs/configuration/transports.rst
@@ -230,7 +230,7 @@ Tools like `EasyRSA <https://github.com/OpenVPN/easy-rsa>`_ make this very easy:
      ./easyrsa build-ca nopass
 
      for host in "${HOSTS[@]}"; do
-         ./easyrsa build-serverClient-full $host nopass
+         ./easyrsa --subject-alt-name=DNS:$host build-serverClient-full $host nopass
          echo cert for host $host available at pki/issued/$host.crt
          echo key for host $host available at pki/private/$host.key
      done


### PR DESCRIPTION
This seems to be an ongoing issue with Go > 1.15. See #357, #900.