### PR TITLE
circleci: fix docs push auth

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,7 +168,6 @@ workflows:
             branches:
               only:
                 - master
-                - fix-docs-push-auth
 
 jobs:
   quickcheck-docs:


### PR DESCRIPTION
In commit 4f950bb60 we switched the publish workflow to use HTTPS and changed CircleCI config accordingly. However, that wasn't working. The error we get after merge to `master`, when we run the job, is: `The key you are authenticating with has been marked as read only.`

The reason is that CircleCI configures SSH URL rewriting, which takes precedence. 

Fix by using git's `url.<base>.insteadOf` config to rewrite both HTTPS and SSH URLs to use HTTPS with the GitHub token. This ensures the token is used regardless of any SSH configuration.