### PR TITLE
circleci: DRY docs jobs + update image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,6 +101,7 @@ workflows:
     when: << pipeline.parameters.do_ci >>
     jobs:
       - run-docs-publish-sh:
+          name: quickcheck-docs
           push: false
       - quickcheck-go:
           name: quickcheck-go-amd64-linux-1.25.6
@@ -152,6 +153,7 @@ workflows:
   publish-zrepl.github.io:
     jobs:
       - run-docs-publish-sh:
+          name: publish-zrepl.github.io
           push: true
           context:
             - zrepl-github-io-deploy


### PR DESCRIPTION
Consolidate `quickcheck-docs` and `publish-zrepl-github-io` jobs into a
single parameterized `run-docs-publish-sh` job with a `push` boolean.
Don't run `make docs` anymore, it's run by `publish.sh` internally
anyway.

The cimg includes `make`, and we don't need Go to build the docs.

Drive-by update to `cimg/base:current` - we pinned all important build
inputs for docs using `uv`, and the inputs we use from the `cimg`
(git, make) are stable.
