### PR TITLE
docs: fix GitHub pages rendering

### DIFF
--- a/docs/publish.sh
+++ b/docs/publish.sh
@@ -54,6 +54,9 @@ git reset --hard origin/master
 echo "Cleaning GitHub pages repo..."
 git rm -rf . || true
 
+# GitHub Pages https://github.blog/news-insights/the-library/bypassing-jekyll-on-github-pages/
+touch .nojekyll
+
 # Build docs
 echo "Building docs..."
 cd "$ROOTDIR"


### PR DESCRIPTION
We need the `.nojekyll` file to render `zrepl.github.io` properly.

Before 4f950bb , `sphinx-multiversion` rendered `.nojekyll`.
