### PR TITLE
circleci: run platformtest on both Ubuntu 22.04 and 24.04

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,6 +130,7 @@ workflows:
               goversion: [*latest-go-release]
               goos: ["linux"]
               goarch: ["amd64"]
+              image: ["ubuntu-2204:current", "ubuntu-2404:current"]
           requires:
             - test-go
             - quickcheck-go-<< matrix.goarch >>-<< matrix.goos >>-<< matrix.goversion >>
@@ -233,8 +234,10 @@ jobs:
         type: string
       goarch:
         type: string
+      image:
+        type: string
     machine:
-      image: ubuntu-2204:current
+      image: <<parameters.image>>
     resource_class: medium
     environment:
       GOOS: <<parameters.goos>>


### PR DESCRIPTION
- Add `image` matrix parameter to the `platformtest` job so it runs on both `ubuntu-2204:current` and `ubuntu-2404:current`
- Covers both current Ubuntu LTS releases for platform testing