### PR TITLE
zfs: fix platformtest compat with ZFS 2.3 & 2.4

### DIFF
--- a/internal/platformtest/tests/undestroyableSnapshotParsing.go
+++ b/internal/platformtest/tests/undestroyableSnapshotParsing.go
@@ -31,7 +31,7 @@ func UndestroyableSnapshotParsing(t *platformtest.Context) {
 			panic(dse.Filesystem)
 		}
 		require.Equal(t, []string{"4 5 6"}, dse.Undestroyable)
-		require.Equal(t, []string{"dataset is busy"}, dse.Reason)
+		require.True(t, dse.AllReasonIsHold(), "expected hold reason, got %v", dse.Reason)
 	}
 
 }


### PR DESCRIPTION
The error message when destroying a held snapshot no longer is `dataset is busy`  but `it's being held. Run 'zfs holds -r <snapshot>' to see holders.`

The existing `destroySnapshotsErrorRegexp` parses both formats correctly, but downstream test assertions in platformtest were checking for the literal `dataset is busy` string.

refs
- the PR that adds ZFS 2.3 & 2.4 to CI: https://github.com/zrepl/zrepl/pull/921